### PR TITLE
DASHBUILDE-91: Filter UI Controls

### DIFF
--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/DashboardFactory.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/DashboardFactory.java
@@ -15,17 +15,36 @@
  */
 package org.jbpm.dashboard.renderer.client.panel;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
 import org.dashbuilder.renderer.client.metric.MetricDisplayer;
 import org.dashbuilder.renderer.client.table.TableDisplayer;
+import org.jboss.errai.ioc.client.api.ManagedInstance;
 
+@ApplicationScoped
 public class DashboardFactory {
 
+    private final ManagedInstance<MetricDisplayer> metricDisplayers;
+    private final ManagedInstance<TableDisplayer> tableDisplayers;
+
+    protected DashboardFactory() {
+        this(null, null);
+    }
+
+    @Inject
+    public DashboardFactory(final ManagedInstance<MetricDisplayer> metricDisplayers,
+                            final ManagedInstance<TableDisplayer> tableDisplayers) {
+        this.metricDisplayers = metricDisplayers;
+        this.tableDisplayers = tableDisplayers;
+    }
+
     public MetricDisplayer createMetricDisplayer() {
-        return new MetricDisplayer();
+        return metricDisplayers.get();
     }
 
     public TableDisplayer createTableDisplayer() {
-        return new TableDisplayer();
+        return tableDisplayers.get();
     }
 }
 


### PR DESCRIPTION
Hey @dgutierr , @manstis @cristianonicolai 
This commit fixes a compilation error (and fixes the `kie-wb-distributions` build too) that was due to the commit from [this PR in Dashbuilder](https://github.com/dashbuilder/dashbuilder/pull/291).
Sorry for the inconveniences guys.