### PR TITLE
JBPM-5695: Exception in Task list for restarted Kie server

### DIFF
--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/menu/ServerTemplateSelectorMenuBuilder.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/menu/ServerTemplateSelectorMenuBuilder.java
@@ -115,7 +115,9 @@ public class ServerTemplateSelectorMenuBuilder implements MenuFactory.CustomMenu
     }
 
     public void onServerTemplateUpdated(@Observes final ServerTemplateUpdated serverTemplateUpdated) {
-        loadServerTemplates();
+        if(serverTemplateUpdated.getServerTemplate().getServerInstanceKeys().isEmpty()){
+            loadServerTemplates();
+        }
     }
 
     public void onKieServerDataSetRegistered(@Observes final KieServerDataSetRegistered kieServerDataSetRegistered) {

--- a/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/menu/ServerTemplateSelectorMenuBuilderTest.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/menu/ServerTemplateSelectorMenuBuilderTest.java
@@ -23,6 +23,7 @@ import com.google.gwtmockito.GwtMockitoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.controller.api.model.events.ServerTemplateUpdated;
 import org.kie.server.controller.api.model.runtime.ServerInstanceKey;
 import org.kie.server.controller.api.model.spec.ServerTemplate;
 import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
@@ -163,6 +164,35 @@ public class ServerTemplateSelectorMenuBuilderTest {
         verify(view).addServerTemplate(serverTemplateId);
         verify(view).selectServerTemplate(serverTemplateId);
         verify(view).setVisible(false);
+
+        verifyNoMoreInteractions(view);
+    }
+
+    @Test
+    public void testServerTemplateUpdatedWithoutServerInstance() {
+        final String serverTemplateId = "id1";
+        final ServerTemplate st1 = new ServerTemplate(serverTemplateId, "kie-server-template1");
+        when(specManagementService.listServerTemplates()).thenReturn(Collections.singletonList(st1));
+
+        serverTemplateSelectorMenuBuilder.onServerTemplateUpdated(new ServerTemplateUpdated(st1));
+
+        verify(specManagementService).listServerTemplates();
+        verify(view).removeAllServerTemplates();
+        verify(view,never()).addServerTemplate(serverTemplateId);
+        verify(view).setVisible(false);
+        verify(view).getSelectedServerTemplate();
+
+        verifyNoMoreInteractions(view);
+    }
+
+    @Test
+    public void testServerTemplateUpdatedWithServerInstance() {
+        final String serverTemplateId = "id1";
+        final ServerTemplate st1 = new ServerTemplate(serverTemplateId, "kie-server-template1");
+        st1.addServerInstance(new ServerInstanceKey());
+        when(specManagementService.listServerTemplates()).thenReturn(Collections.singletonList(st1));
+
+        serverTemplateSelectorMenuBuilder.onServerTemplateUpdated(new ServerTemplateUpdated(st1));
 
         verifyNoMoreInteractions(view);
     }


### PR DESCRIPTION
Catch KieServicesHttpException thrown when the kie-server still is not ready to execute dataset queries while it's registering dataSetDefinitions 