### PR TITLE
Enable findbugs.failOnViolation

### DIFF
--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/util/UTCTimeBoxImplShared.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/util/UTCTimeBoxImplShared.java
@@ -28,22 +28,22 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
     protected DateTimeFormat timeFormat;
 
     // ----------------------------------------------------------------------
-    
+
     /**
      * Sets the DateTimeFormat for this UTCTimeBox. The HTML5
      * implementation will ignore this.
      */
     @Override
-    public void setTimeFormat(DateTimeFormat timeFormat) { 
+    public void setTimeFormat(DateTimeFormat timeFormat) {
         this.timeFormat = timeFormat;
     }
-    
+
     /**
      * Sets the visible length of the time input. The HTML5
      * implementation will ignore this.
      */
     @Override
-    public void setVisibleLength(int length) {}    
+    public void setVisibleLength(int length) {}
 
     /**
      * Validates the value that has been typed into the text input.
@@ -51,7 +51,7 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
      */
     @Override
     public void validate() {}
-    
+
 
     /**
      * Sets the time value (as milliseconds since midnight independent
@@ -60,26 +60,28 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
     @Override
     public final void setValue(Long value) {
         setValue(value, false);
-    }    
-    
+    }
+
     // ----------------------------------------------------------------------
-    
+
     public UTCTimeBoxImplShared() {
         if (fallbackTimeFormats == null) {
-            fallbackTimeFormats = new DateTimeFormat[fallbackFormatStrings.length];
-            for (int i=0; i<fallbackFormatStrings.length; i++) {
-                fallbackTimeFormats[i] = DateTimeFormat.getFormat(fallbackFormatStrings[i]);
+            // Initialize the array fully in local var before assigning to class field to avoid synchronization issues
+            DateTimeFormat[] formats = new DateTimeFormat[fallbackFormatStrings.length];
+            for (int i = 0; i < formats.length; i++) {
+                formats[i] = DateTimeFormat.getFormat(fallbackFormatStrings[i]);
             }
-        }    
+            fallbackTimeFormats = formats;
+        }
     }
-    
+
     // ----------------------------------------------------------------------
     // parsing and formatting
 
     protected final String value2text( Long value ) {
         return formatUsingFormat(value, timeFormat);
     }
-    
+
     protected final Long text2value( String text ) {
 
         if (text == null ){
@@ -94,7 +96,7 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
             if (text.endsWith("p") || text.endsWith("a")) {
                 text += "m";
             }
-            
+
             Long ret = parseUsingFallbacks(text, timeFormat);
             if (ret == null) {
                 ret = parseUsingFallbacksWithColon(text, timeFormat);
@@ -102,7 +104,7 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
             return ret;
         }
     }
-    
+
     /**
      * Formats the value provided with the specified DateTimeFormat
      */
@@ -119,7 +121,7 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
             return fmt.format(date);
         }
     }
-    
+
     /**
      * Attempts to insert a colon so that a value without a colon can
      * be parsed.
@@ -153,13 +155,13 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
             return null;
         }
     }
-    
+
     protected static final Long parseUsingFormat(String text, DateTimeFormat fmt) {
         Date date = new Date(0);
         int num = fmt.parse(text, 0, date);
         return (num != 0) ? new Long(normalizeInLocalRange(date.getTime() - UTCDateBox.timezoneOffsetMillis(date))) : null;
     }
-    
+
     protected static final Long parseUsingFallbacks(String text, DateTimeFormat primaryTimeFormat) {
         Long ret = parseUsingFormat(text, primaryTimeFormat);
         for (int i = 0; ret == null && i < fallbackTimeFormats.length; i++) {
@@ -172,5 +174,5 @@ public abstract class UTCTimeBoxImplShared extends Composite implements UTCTimeB
         return (time + UTCDateBox.DAY_IN_MS) % UTCDateBox.DAY_IN_MS;
     }
 
-    
+
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
@@ -41,8 +41,8 @@ import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.QueryServicesClient;
 import org.ocpsoft.prettytime.PrettyTime;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
 
 @Service
 @ApplicationScoped
@@ -105,7 +105,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
             if(nis.getNodeType().equals("HumanTaskNode")){
                 logs.add(new RuntimeLogSummary(nis.getId(), prettyDateFormatter.format(nis.getDate()), "Task '" + nis.getName() + "' was created", "System"));
                 for(TaskEventInstance te : allTaskEventsByProcessInstanceId){
-                    if(te.getWorkItemId() != null && nis.getId() == te.getWorkItemId() &&
+                    if(te.getWorkItemId() != null && te.getWorkItemId().equals(nis.getId()) &&
                         (te.getType().equals("CLAIMED") || te.getType().equals("RELEASED") || te.getType().equals("COMPLETED"))){
                             logs.add(new RuntimeLogSummary(nis.getId(), "- " + prettyDateFormatter.format(te.getLogTime()), "Task '" + nis.getName() +
                                     "' was " + te.getType().toLowerCase() + " by user " + te.getUserId(), "Human"));
@@ -191,7 +191,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
                 if(nis.getNodeType().equals("HumanTaskNode")){
                     logs.add(new RuntimeLogSummary(nis.getId(), prettyDateFormatter.format(nis.getDate()), nis.getName() + "("+nis.getNodeType()+")", "System"));
                     for(TaskEventInstance te : allTaskEventsByProcessInstanceId){
-                        if(te.getWorkItemId() != null && nis.getId() == te.getWorkItemId()){
+                        if(te.getWorkItemId() != null && te.getWorkItemId().equals(nis.getId())){
                             if(te.getType().equals("ADDED")){
                                 logs.add(new RuntimeLogSummary(nis.getId(), "- " + prettyDateFormatter.format(te.getLogTime()), te.getUserId() + "->" +te.getType(), "System"));
                             }else{

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
 \*\/$
 ]]>
     </checkstyle.header.template>
+    <findbugs.failOnViolation>true</findbugs.failOnViolation>
   </properties>
 
   <modules>


### PR DESCRIPTION
Enable findbugs-maven-plugin to fail the build when serious bug has been identified. Findbugs plugin is only executed when the build is run with `-Dfull` (which is the case in kie-jenkins CI jobs).

At the same time I'm providing fixes to 2 issues identified by the plugin.

The configuration of the plugin can be found in [droolsjbpm-build-bootstrap/pom.xml](https://github.com/kiegroup/droolsjbpm-build-bootstrap/blob/master/pom.xml#L1165-L1182) and has been already fine-tuned by QE to only fail the build in cases where it's almost certain there's a bug.