### PR TITLE
JBPM-5736, JBPM-5985, JBPM-5723 & JBPM-5911 Form synchronization when model changes

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessor.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessor.java
@@ -30,12 +30,13 @@ import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContext;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.dynamic.service.shared.RenderMode;
-import org.kie.workbench.common.forms.jbpm.model.authoring.JBPMVariable;
 import org.kie.workbench.common.forms.jbpm.model.authoring.task.TaskFormModel;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.util.BPMNVariableUtils;
 import org.kie.workbench.common.forms.model.FormDefinition;
+import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -105,7 +106,7 @@ public class TaskFormValuesProcessor extends KieWorkbenchFormsValuesProcessor<Ta
 
     @Override
     protected Collection<FormDefinition> generateDefaultFormsForContext(TaskRenderingSettings settings) {
-        List<JBPMVariable> variables = new ArrayList<>();
+        List<ModelProperty> properties = new ArrayList<>();
 
         TaskDefinition task = settings.getTask();
 
@@ -116,14 +117,15 @@ public class TaskFormValuesProcessor extends KieWorkbenchFormsValuesProcessor<Ta
         taskData.forEach((name, type) -> {
             // filter not needed variables
             if (BPMNVariableUtils.isValidInputName(name)) {
-                variables.add(new JBPMVariable(name,
-                                               type));
+                properties.add(ModelPropertiesGenerator.createModelProperty(name,
+                                                                            BPMNVariableUtils.getRealTypeForInput(type),
+                                                                            settings.getMarshallerContext().getClassloader()));
             }
         });
 
         TaskFormModel formModel = new TaskFormModel(task.getProcessId(),
                                                     task.getFormName(),
-                                                    variables);
+                                                    properties);
 
         Collection<FormDefinition> forms = dynamicBPMNFormGenerator.generateTaskForms(formModel,
                                                                                       settings.getMarshallerContext().getClassloader());

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
@@ -16,22 +16,17 @@
 
 package org.jbpm.workbench.forms.display.backend.provider;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.enterprise.inject.Instance;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonParser;
-import org.apache.commons.io.IOUtils;
-import org.jbpm.workbench.forms.service.providing.RenderingSettings;
 import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
+import org.jbpm.workbench.forms.service.providing.RenderingSettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
-import org.kie.workbench.common.forms.commons.layout.impl.DynamicFormLayoutTemplateGenerator;
+import org.kie.workbench.common.forms.commons.shared.layout.impl.DynamicFormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.FormValuesProcessorImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors.MultipleSubFormFieldValueProcessor;
@@ -50,7 +45,8 @@ import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerialize
 import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
 import org.mockito.Mock;
 
-import static junit.framework.TestCase.*;
+import static junit.framework.TestCase.assertFalse;
+import static junit.framework.TestCase.assertNotNull;
 import static org.mockito.Mockito.*;
 
 public abstract class AbstractFormProvidingEngineTest<SETTINGS extends RenderingSettings, PROCESSOR extends KieWorkbenchFormsValuesProcessor<SETTINGS>, PROVIDER extends AbstractKieWorkbenchFormsProvider> {
@@ -156,41 +152,5 @@ public abstract class AbstractFormProvidingEngineTest<SETTINGS extends Rendering
                     result.isEmpty());
 
         checkRuntimeValues(result);
-    }
-
-    protected String getFormContent() {
-
-        try {
-            JsonArray formsArray = new JsonArray();
-
-            JsonParser parser = new JsonParser();
-
-            String content = IOUtils.toString(this.getClass().getResourceAsStream("/forms/Client.frm"));
-
-            formsArray.add(parser.parse(content));
-
-            content = IOUtils.toString(this.getClass().getResourceAsStream("/forms/InvoiceLine.frm"));
-
-            formsArray.add(parser.parse(content));
-
-            content = IOUtils.toString(this.getClass().getResourceAsStream("/forms/Invoice.frm"));
-
-            formsArray.add(parser.parse(content));
-
-            content = IOUtils.toString(this.getClass().getResourceAsStream("/forms/invoices-taskform.frm"));
-
-            formsArray.add(parser.parse(content));
-
-            content = IOUtils.toString(this.getClass().getResourceAsStream("/forms/modify-taskform.frm"));
-
-            formsArray.add(parser.parse(content));
-
-            Gson gson = new Gson();
-
-            return gson.toJson(formsArray);
-        } catch (IOException e) {
-        }
-
-        return null;
     }
 }

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.forms.display.backend.provider;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.enterprise.inject.Instance;
+
+import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
+import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
+import org.jbpm.workbench.forms.display.backend.provider.model.InvoiceLine;
+import org.jbpm.workbench.forms.service.providing.RenderingSettings;
+import org.junit.Before;
+import org.junit.Test;
+import org.kie.internal.task.api.ContentMarshallerContext;
+import org.kie.workbench.common.forms.commons.shared.layout.impl.DynamicFormLayoutTemplateGenerator;
+import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
+import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.FormValuesProcessorImpl;
+import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors.MultipleSubFormFieldValueProcessor;
+import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors.SubFormFieldValueProcessor;
+import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.validation.impl.ContextModelConstraintsExtractorImpl;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FieldValueProcessor;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FormValuesProcessor;
+import org.kie.workbench.common.forms.dynamic.service.shared.impl.MapModelRenderingContext;
+import org.kie.workbench.common.forms.fields.test.TestFieldManager;
+import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.runtime.BPMNRuntimeFormGeneratorService;
+import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
+import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
+import org.kie.workbench.common.forms.model.FieldDefinition;
+import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWorkbenchFormsValuesProcessor<SETTINGS>, SETTINGS extends RenderingSettings> {
+
+    static final String ID = "id";
+    static final String NAME = "name";
+    static final String ADDRESS = "address";
+    static final String PRODUCT = "product";
+    static final String QUANTITY = "quantity";
+    static final String PRICE = "price";
+    static final String TOTAL = "total";
+    static final String CLIENT = "client";
+    static final String LINES = "lines";
+    static final String COMMENTS = "comments";
+    static final String DATE = "date";
+    static final String INVOICE = "invoice";
+
+    static final int EXPECTED_MODEL_VALIDATIONS = 3;
+    static final int EXPECTED_FORMS = 4;
+
+    @Mock
+    ContentMarshallerContext marshallerContext;
+
+    FormValuesProcessor formValuesProcessor;
+
+    DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
+
+    BackendFormRenderingContextManagerImpl backendFormRenderingContextManager;
+
+    BPMNRuntimeFormGeneratorService runtimeFormGeneratorService;
+
+    KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings;
+
+    SETTINGS renderingSettings;
+
+    PROCESSOR processor;
+
+    @Before
+    public void init() {
+        List<FieldValueProcessor> processors = Arrays.asList(new SubFormFieldValueProcessor(),
+                                                             new MultipleSubFormFieldValueProcessor());
+
+        Instance<FieldValueProcessor<? extends FieldDefinition, ?, ?>> fieldValueProcessors = mock(Instance.class);
+        when(fieldValueProcessors.iterator()).then(proc -> processors.iterator());
+
+        formValuesProcessor = new FormValuesProcessorImpl(fieldValueProcessors);
+
+        backendFormRenderingContextManager = new BackendFormRenderingContextManagerImpl(formValuesProcessor,
+                                                                                        new ContextModelConstraintsExtractorImpl());
+
+        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
+                                                                          new DynamicFormLayoutTemplateGenerator());
+
+        dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(runtimeFormGeneratorService);
+
+        processor = getProcessorInstance(new FormDefinitionSerializerImpl(new FieldSerializer(),
+                                                                          new FormModelSerializer()),
+                                         backendFormRenderingContextManager,
+                                         dynamicBPMNFormGenerator);
+
+        when(marshallerContext.getClassloader()).thenReturn(this.getClass().getClassLoader());
+    }
+
+    @Test
+    public void testGenerateRenderingContextWithExistingForms() {
+        Map<String, String> formData = new HashMap<>();
+
+        formData.put("invoice",
+                     Invoice.class.getName());
+
+        renderingSettings = getFullRenderingSettings();
+
+        kieWorkbenchFormRenderingSettings = processor.generateRenderingContext(renderingSettings);
+
+        checkGeneratedContext();
+    }
+
+    @Test
+    public void testGenerateRenderingContextWithoutForms() {
+
+        renderingSettings = getRenderingSettingsWithoutForms();
+
+        kieWorkbenchFormRenderingSettings = processor.generateRenderingContext(renderingSettings,
+                                                                               true);
+
+        checkGeneratedContext();
+    }
+
+    protected void checkGeneratedContext() {
+        assertNotNull(kieWorkbenchFormRenderingSettings);
+
+        MapModelRenderingContext formRenderingContext = kieWorkbenchFormRenderingSettings.getRenderingContext();
+
+        assertNotNull(formRenderingContext);
+
+        assertFalse(formRenderingContext.getModelConstraints().isEmpty());
+        assertEquals(EXPECTED_MODEL_VALIDATIONS,
+                     formRenderingContext.getModelConstraints().size());
+
+        assertFalse(formRenderingContext.getAvailableForms().isEmpty());
+        assertEquals(EXPECTED_FORMS,
+                     formRenderingContext.getAvailableForms().size());
+    }
+
+    @Test
+    public void testProcessFormValues() {
+        testGenerateRenderingContextWithExistingForms();
+
+        Map<String, Object> formValues = getFormValues();
+
+        Map<String, Object> outputValues = processor.generateRuntimeValuesMap(kieWorkbenchFormRenderingSettings.getTimestamp(),
+                                                                              formValues);
+
+        assertNotNull(outputValues);
+        assertFalse(outputValues.isEmpty());
+
+        assertNotNull(outputValues.get(INVOICE));
+        assertTrue(outputValues.get(INVOICE) instanceof Invoice);
+
+        Invoice invoice = (Invoice) outputValues.get(INVOICE);
+
+        Map<String, Object> invoiceMap = (Map<String, Object>) formValues.get(INVOICE);
+
+        Map<String, Object> clientMap = (Map<String, Object>) invoiceMap.get(CLIENT);
+
+        assertNotNull(invoice.getClient());
+        assertEquals(clientMap.get("id"),
+                     invoice.getClient().getId());
+        assertEquals(clientMap.get("name"),
+                     invoice.getClient().getName());
+        assertEquals(clientMap.get("address"),
+                     invoice.getClient().getAddress());
+
+        List<Map<String, Object>> linesMap = (List<Map<String, Object>>) invoiceMap.get(LINES);
+
+        assertNotNull(invoice.getLines());
+        assertEquals(linesMap.size(),
+                     invoice.getLines().size());
+
+        Map<String, Object> lineMap = linesMap.get(0);
+        InvoiceLine line = invoice.getLines().get(0);
+
+        assertEquals(lineMap.get("product"),
+                     line.getProduct());
+        assertEquals(lineMap.get("quantity"),
+                     line.getQuantity());
+        assertEquals(lineMap.get("price"),
+                     line.getPrice());
+        assertEquals(lineMap.get("total"),
+                     line.getTotal());
+
+        assertEquals(invoiceMap.get("comments"),
+                     invoice.getComments());
+        assertEquals(invoiceMap.get("total"),
+                     invoice.getTotal());
+        assertEquals(invoiceMap.get("date"),
+                     invoice.getDate());
+    }
+
+    protected Map<String, Object> getFormValues() {
+        Map<String, Object> formValues = new HashMap<>();
+
+        Map<String, Object> clientMap = new HashMap<>();
+        clientMap.put(ID,
+                      new Long(1234));
+        clientMap.put(NAME,
+                      "John Snow");
+        clientMap.put(ADDRESS,
+                      "Winterfell");
+
+        List<Map<String, Object>> linesMap = new ArrayList<>();
+
+        Map<String, Object> lineMap = new HashMap<>();
+
+        lineMap.put(PRODUCT,
+                    "Really Dangerous Sword");
+        lineMap.put(QUANTITY,
+                    1);
+        lineMap.put(PRICE,
+                    100.5);
+        lineMap.put(TOTAL,
+                    100.5);
+
+        linesMap.add(lineMap);
+
+        Map<String, Object> invoiceMap = new HashMap<>();
+        invoiceMap.put(CLIENT,
+                       clientMap);
+        invoiceMap.put(LINES,
+                       linesMap);
+        invoiceMap.put(TOTAL,
+                       100.5);
+        invoiceMap.put(COMMENTS,
+                       "Everything was perfect");
+        invoiceMap.put(DATE,
+                       new Date());
+
+        formValues.put(INVOICE,
+                       invoiceMap);
+
+        return formValues;
+    }
+
+    abstract SETTINGS getFullRenderingSettings();
+
+    abstract SETTINGS getRenderingSettingsWithoutForms();
+
+    abstract PROCESSOR getProcessorInstance(FormDefinitionSerializer serializer,
+                                            BackendFormRenderingContextManager backendFormRenderingContextManager,
+                                            DynamicBPMNFormGenerator dynamicBPMNFormGenerator);
+}

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.forms.display.backend.provider;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
+import org.jbpm.workbench.forms.display.backend.provider.util.FormContentReader;
+import org.jbpm.workbench.forms.service.providing.ProcessRenderingSettings;
+import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
+import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
+import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProcessFormsValuesProcessorTest extends AbstractFormsValuesProcessorTest<ProcessFormsValuesProcessor, ProcessRenderingSettings> {
+
+    @Mock
+    ProcessDefinition process;
+
+    @Override
+    public void init() {
+        super.init();
+
+        when(process.getId()).thenReturn("invoices");
+    }
+
+    @Override
+    ProcessFormsValuesProcessor getProcessorInstance(FormDefinitionSerializer serializer,
+                                                     BackendFormRenderingContextManager backendFormRenderingContextManager,
+                                                     DynamicBPMNFormGenerator dynamicBPMNFormGenerator) {
+        return new ProcessFormsValuesProcessor(new FormDefinitionSerializerImpl(new FieldSerializer(),
+                                                                                new FormModelSerializer()),
+                                               backendFormRenderingContextManager,
+                                               dynamicBPMNFormGenerator);
+    }
+
+    @Override
+    ProcessRenderingSettings getFullRenderingSettings() {
+        return getRenderSettings(FormContentReader.getStartProcessForms());
+    }
+
+    @Override
+    ProcessRenderingSettings getRenderingSettingsWithoutForms() {
+        return getRenderSettings(null);
+    }
+
+    private ProcessRenderingSettings getRenderSettings(String formContent) {
+        Map<String, String> formData = new HashMap<>();
+
+        formData.put("invoice",
+                     Invoice.class.getName());
+
+        return new ProcessRenderingSettings(process,
+                                            formData,
+                                            formContent,
+                                            marshallerContext);
+    }
+}

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.forms.display.backend.provider;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jbpm.workbench.forms.display.backend.provider.model.Client;
+import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
+import org.jbpm.workbench.forms.display.backend.provider.model.InvoiceLine;
+import org.jbpm.workbench.forms.display.backend.provider.util.FormContentReader;
+import org.jbpm.workbench.forms.service.providing.TaskRenderingSettings;
+import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
+import org.junit.runner.RunWith;
+import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
+import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
+import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskFormValuesProcessorTest extends AbstractFormsValuesProcessorTest<TaskFormValuesProcessor, TaskRenderingSettings> {
+
+    @Mock
+    protected TaskDefinition task;
+
+    @Override
+    public void init() {
+        super.init();
+        when(task.getFormName()).thenReturn("modify");
+
+        Map<String, String> variables = new HashMap<>();
+        variables.put(INVOICE,
+                      Invoice.class.getName());
+
+        when(task.getTaskInputDefinitions()).thenReturn(variables);
+        when(task.getTaskOutputDefinitions()).thenReturn(variables);
+    }
+
+    @Override
+    TaskRenderingSettings getFullRenderingSettings() {
+        return getRenderingSettings(FormContentReader.getTaskForms());
+    }
+
+    @Override
+    TaskRenderingSettings getRenderingSettingsWithoutForms() {
+        return getRenderingSettings(null);
+    }
+
+    private TaskRenderingSettings getRenderingSettings(String formContent) {
+        Invoice invoice = new Invoice();
+        invoice.setClient(new Client(new Long(1234),
+                                     "Dad Smurf",
+                                     "Mushroom #1"));
+        invoice.setDate(new Date());
+        invoice.setComments("It could be better...");
+        invoice.setTotal(300.50);
+
+        List<InvoiceLine> lines = new ArrayList<>();
+        lines.add(new InvoiceLine("Magical book",
+                                  1,
+                                  100.5,
+                                  200.0));
+        lines.add(new InvoiceLine("Nice red hat",
+                                  1,
+                                  50.0,
+                                  150.0));
+
+        invoice.setLines(lines);
+
+        Map<String, Object> inputs = new HashMap<>();
+
+        inputs.put(INVOICE,
+                   invoice);
+
+        return new TaskRenderingSettings(task,
+                                         inputs,
+                                         new HashMap<>(),
+                                         formContent,
+                                         marshallerContext);
+    }
+
+    @Override
+    TaskFormValuesProcessor getProcessorInstance(FormDefinitionSerializer serializer,
+                                                 BackendFormRenderingContextManager backendFormRenderingContextManager,
+                                                 DynamicBPMNFormGenerator dynamicBPMNFormGenerator) {
+        return new TaskFormValuesProcessor(serializer,
+                                           backendFormRenderingContextManager,
+                                           dynamicBPMNFormGenerator);
+    }
+}

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/process/AbstractStartProcessFormTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/process/AbstractStartProcessFormTest.java
@@ -22,14 +22,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jbpm.workbench.forms.service.providing.ProcessRenderingSettings;
-import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
 import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
 import org.jbpm.workbench.forms.display.backend.provider.AbstractFormProvidingEngineTest;
 import org.jbpm.workbench.forms.display.backend.provider.AbstractKieWorkbenchFormsProvider;
 import org.jbpm.workbench.forms.display.backend.provider.ProcessFormsValuesProcessor;
 import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
 import org.jbpm.workbench.forms.display.backend.provider.model.InvoiceLine;
+import org.jbpm.workbench.forms.display.backend.provider.util.FormContentReader;
+import org.jbpm.workbench.forms.service.providing.ProcessRenderingSettings;
+import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
 import org.junit.Test;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
@@ -37,8 +38,7 @@ import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public abstract class AbstractStartProcessFormTest<PROVIDER extends AbstractKieWorkbenchFormsProvider> extends AbstractFormProvidingEngineTest<ProcessRenderingSettings, ProcessFormsValuesProcessor, PROVIDER> {
@@ -65,7 +65,7 @@ public abstract class AbstractStartProcessFormTest<PROVIDER extends AbstractKieW
 
         return new ProcessRenderingSettings(process,
                                             formData,
-                                            getFormContent(),
+                                            FormContentReader.getStartProcessForms(),
                                             marshallerContext);
     }
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/task/AbstractTaskFormProvidingTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/task/AbstractTaskFormProvidingTest.java
@@ -22,8 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.jbpm.workbench.forms.service.providing.TaskRenderingSettings;
-import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
 import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
 import org.jbpm.workbench.forms.display.backend.provider.AbstractFormProvidingEngineTest;
 import org.jbpm.workbench.forms.display.backend.provider.AbstractKieWorkbenchFormsProvider;
@@ -31,6 +29,9 @@ import org.jbpm.workbench.forms.display.backend.provider.TaskFormValuesProcessor
 import org.jbpm.workbench.forms.display.backend.provider.model.Client;
 import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
 import org.jbpm.workbench.forms.display.backend.provider.model.InvoiceLine;
+import org.jbpm.workbench.forms.display.backend.provider.util.FormContentReader;
+import org.jbpm.workbench.forms.service.providing.TaskRenderingSettings;
+import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
 import org.junit.Test;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
@@ -38,8 +39,7 @@ import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertNotNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 public abstract class AbstractTaskFormProvidingTest<PROVIDER extends AbstractKieWorkbenchFormsProvider> extends AbstractFormProvidingEngineTest<TaskRenderingSettings, TaskFormValuesProcessor, PROVIDER> {
@@ -81,13 +81,13 @@ public abstract class AbstractTaskFormProvidingTest<PROVIDER extends AbstractKie
 
         Map<String, Object> inputs = new HashMap<>();
 
-        inputs.put("in_invoice",
+        inputs.put("invoice",
                    invoice);
 
         return new TaskRenderingSettings(task,
                                          inputs,
                                          new HashMap<>(),
-                                         getFormContent(),
+                                         FormContentReader.getTaskForms(),
                                          marshallerContext);
     }
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/util/FormContentReader.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/util/FormContentReader.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jbpm.workbench.forms.display.backend.provider.util;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonParser;
+import org.apache.commons.io.IOUtils;
+
+public class FormContentReader {
+
+    public static final String getStartProcessForms() {
+        return getFormContent("/forms/invoices-taskform.frm");
+    }
+
+    public static final String getTaskForms() {
+        return getFormContent("/forms/modify-taskform.frm");
+    }
+
+    private static String getFormContent(String formPath) {
+
+        try {
+            JsonArray formsArray = new JsonArray();
+
+            JsonParser parser = new JsonParser();
+
+            String content = IOUtils.toString(new InputStreamReader(FormContentReader.class.getResourceAsStream("/forms/Client.frm")));
+
+            formsArray.add(parser.parse(content));
+
+            content = IOUtils.toString(new InputStreamReader(FormContentReader.class.getResourceAsStream("/forms/InvoiceLine.frm")));
+
+            formsArray.add(parser.parse(content));
+
+            content = IOUtils.toString(new InputStreamReader(FormContentReader.class.getResourceAsStream("/forms/Invoice.frm")));
+
+            formsArray.add(parser.parse(content));
+
+            content = IOUtils.toString(new InputStreamReader(FormContentReader.class.getResourceAsStream(formPath)));
+
+            formsArray.add(parser.parse(content));
+
+            Gson gson = new Gson();
+
+            return gson.toJson(formsArray);
+        } catch (IOException e) {
+        }
+
+        return null;
+    }
+}

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/resources/forms/invoices-taskform.frm
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/resources/forms/invoices-taskform.frm
@@ -4,10 +4,14 @@
   "model": {
     "processId": "invoices",
     "processName": "invoices",
-    "variables": [
+    "properties": [
       {
         "name": "invoice",
-        "type": "org.jbpm.workbench.forms.display.backend.provider.model.Invoice"
+        "typeInfo": {
+          "type": "OBJECT",
+          "className": "org.jbpm.workbench.forms.display.backend.provider.model.Invoice",
+          "multiple": false
+        }
       }
     ],
     "formModelType": "org.kie.workbench.common.forms.jbpm.model.authoring.process.BusinessProcessFormModel"

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/resources/forms/modify-taskform.frm
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/resources/forms/modify-taskform.frm
@@ -5,12 +5,14 @@
     "processId": "invoices",
     "taskId": "_214D8182-692C-4016-9885-BDD79CDFA8FA",
     "taskName": "modify",
-    "variables": [
+    "properties": [
       {
         "name": "invoice",
-        "type": "org.jbpm.workbench.forms.display.backend.provider.model.Invoice",
-        "inputMapping": "in_invoice",
-        "ouputMapping": "out_invoice"
+        "typeInfo": {
+          "type": "OBJECT",
+          "className": "org.jbpm.workbench.forms.display.backend.provider.model.Invoice",
+          "multiple": false
+        }
       }
     ],
     "formModelType": "org.kie.workbench.common.forms.jbpm.model.authoring.task.TaskFormModel"

--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1556,6 +1556,7 @@
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-adf-engine-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-fields</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-processing-engine</compileSourcesArtifact>
+            <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-layout-generator</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-common-rendering-shared</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-common-rendering-client</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.forms:kie-wb-common-forms-crud-component</compileSourcesArtifact>


### PR DESCRIPTION
This PR adapts code to API changes introduced by:

JBPM-5736: Update taskforms component menu on task/process change.
JBPM-5985: Forms are generated incorrectly after a removal of the process/task variable.
JBPM-5723: If you delete a data field, there is no response in the form connected to it.
JBPM-5911: DatePicker should be created from LocalDate, LocalDateTime and OffsetDateTime data types.

@jsoltes @cristianonicolai   could you take a look?

Relates to:
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/465
https://github.com/kiegroup/kie-wb-common/pull/946
https://github.com/kiegroup/jbpm-designer/pull/633
https://github.com/kiegroup/jbpm-wb/pull/778
https://github.com/kiegroup/kie-wb-distributions/pull/543