### PR TITLE
GUVNOR-3023: Support provisioning of KIE Server instances by Guvnor ALA

### DIFF
--- a/jbpm-wb-integration/jbpm-wb-integration-backend/pom.xml
+++ b/jbpm-wb-integration/jbpm-wb-integration-backend/pom.xml
@@ -153,6 +153,10 @@
       <groupId>org.guvnor</groupId>
       <artifactId>guvnor-ala-wildfly-provider</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.guvnor</groupId>
+      <artifactId>guvnor-ala-openshift-provider</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.uberfire</groupId>


### PR DESCRIPTION
GUVNOR-3023: Support provisioning of KIE Server instances by Guvnor ALA
https://issues.jboss.org/browse/GUVNOR-3023

This was cherry-picked from the work on the 7.2.x branch, and rebased against master.