### PR TITLE
[7.3.x] RHBPMS-4925: HTTP 405 when sending empty signal name to process instance

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalViewImpl.html
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalViewImpl.html
@@ -5,8 +5,9 @@
                 <div class="form-group">
                     <label class="control-label col-md-3" for="signalRefText" data-field="signalRefLabel"></label>
 
-                    <div class="col-md-9">
+                    <div class="col-md-9" data-field="signalRefTextGroup">
                         <input type="text" data-field="signalRefText" id="signalRefText" placeholder="" class="form-control"/>
+                        <span id="helpBlock" class="help-block" for="signalRefText" data-field="signalRefTextHelpBlock"></span>
                     </div>
                 </div>
                 <div class="form-group">

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalViewImpl.java
@@ -29,12 +29,15 @@ import com.google.gwt.user.client.ui.Composite;
 import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
 import org.gwtbootstrap3.client.ui.Button;
 import org.gwtbootstrap3.client.ui.FormLabel;
+import org.gwtbootstrap3.client.ui.HelpBlock;
 import org.gwtbootstrap3.client.ui.SuggestBox;
 import org.gwtbootstrap3.client.ui.TextBox;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.jbpm.workbench.pr.client.resources.i18n.Constants;
+import org.uberfire.client.views.pfly.widgets.FormGroup;
+import org.uberfire.client.views.pfly.widgets.ValidationState;
 import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
@@ -64,8 +67,13 @@ public class ProcessInstanceSignalViewImpl extends Composite implements ProcessI
     @DataField
     public SuggestBox signalRefText;
 
+    @Inject
+    @DataField
+    public HelpBlock signalRefTextHelpBlock;
     public List<Long> processInstanceIds = new ArrayList<Long>();
-
+    @Inject
+    @DataField
+    FormGroup signalRefTextGroup;
     private Constants constants = GWT.create(Constants.class);
 
     private ProcessInstanceSignalPresenter presenter;
@@ -86,7 +94,9 @@ public class ProcessInstanceSignalViewImpl extends Composite implements ProcessI
         clearButton.setText(constants.Clear());
         signalButton.setText(constants.Signal());
         signalRefLabel.setText(constants.Signal_Name());
+        signalRefLabel.setShowRequiredIndicator(true);
         eventLabel.setText(constants.Signal_Data());
+        clearFields();
     }
 
     @Override
@@ -96,19 +106,19 @@ public class ProcessInstanceSignalViewImpl extends Composite implements ProcessI
 
     @EventHandler("signalButton")
     public void signalButton(ClickEvent e) {
-
-        for (Long processInstanceId : this.processInstanceIds) {
-
-            displayNotification(constants.Signalling_Process_Instance() + processInstanceId + " " + constants.Signal() + " = "
-                                        + signalRefText.getText() + " - " + constants.Signal_Data() + " = " + eventText.getText());
-        }
         presenter.signalProcessInstances(this.processInstanceIds);
     }
 
     @EventHandler("clearButton")
     public void clearButton(ClickEvent e) {
+        clearFields();
+    }
+
+    private void clearFields() {
         signalRefText.setValue("");
         eventText.setValue("");
+        signalRefTextHelpBlock.setText("");
+        signalRefTextGroup.clearValidationState();
     }
 
     @Override
@@ -129,5 +139,11 @@ public class ProcessInstanceSignalViewImpl extends Composite implements ProcessI
     @Override
     public void setAvailableSignals(Collection<String> signals) {
         oracle.addAll(signals);
+    }
+
+    @Override
+    public void setHelpText(String text) {
+        signalRefTextGroup.setValidationState(ValidationState.ERROR);
+        signalRefTextHelpBlock.setText(text);
     }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/resources/i18n/Constants.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/resources/i18n/Constants.java
@@ -89,6 +89,8 @@ public interface Constants extends Messages {
 
     String Signaling_Process_Instance();
 
+    String Signal_Name_Required();
+
     String Signaling_Process_Instance_Not_Allowed(Object id);
 
     String Bulk_Signal();

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/resources/org/jbpm/workbench/pr/client/resources/i18n/Constants.properties
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/resources/org/jbpm/workbench/pr/client/resources/i18n/Constants.properties
@@ -25,6 +25,7 @@ No_Process_Instances_Found=No process instances found
 Aborting_Process_Instance_Not_Allowed=Aborting Process Instance Not Allowed (The Process Instance is not Active) (id={0})
 Aborting_Process_Instance=Aborting Process Instance (id={0})
 Signaling_Process_Instance=Signaling Process Instance
+Signal_Name_Required=Signal Name is required
 Signaling_Process_Instance_Not_Allowed=Signaling Process Instance Not Allowed (The Process Instance is not Active) (id={0})
 Bulk_Signal=Bulk Signal
 Related_To_Me=Related To Me

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/signal/ProcessInstanceSignalPresenterTest.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.pr.client.editors.instance.signal;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.enterprise.event.Event;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwtmockito.GwtMockitoTestRunner;
+import org.jbpm.workbench.pr.client.resources.i18n.Constants;
+import org.jbpm.workbench.pr.events.ProcessInstancesUpdateEvent;
+import org.jbpm.workbench.pr.service.ProcessService;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.uberfire.client.mvp.PlaceManager;
+import org.uberfire.client.views.pfly.widgets.ConfirmPopup;
+import org.uberfire.mocks.CallerMock;
+import org.uberfire.mocks.EventSourceMock;
+import org.uberfire.mvp.PlaceRequest;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@RunWith(GwtMockitoTestRunner.class)
+public class ProcessInstanceSignalPresenterTest {
+
+    private static final Long PI_ID = 1L;
+    private static final Long PI_ID2 = 2L;
+    private static final String SERVER_TEMPLATE_ID = "serverTemplateIdTest";
+    private static final String PI_DEPLOYMENT_ID = "deploymentIdTest";
+
+    @Mock
+    public ProcessInstanceSignalPresenter.PopupView view;
+
+    @Mock
+    ConfirmPopup confirmPopup;
+    @Spy
+    Event<ProcessInstancesUpdateEvent> processInstancesUpdatedEvent = new EventSourceMock<>();
+    private CallerMock<ProcessService> remoteProcessServiceCaller;
+    @Mock
+    private ProcessService processService;
+    @Mock
+    private PlaceRequest place;
+    @Mock
+    private PlaceManager placeManager;
+    @InjectMocks
+    private ProcessInstanceSignalPresenter presenter;
+
+    @Before
+    public void setupMocks() {
+        doNothing().when(processInstancesUpdatedEvent).fire(any(ProcessInstancesUpdateEvent.class));
+        remoteProcessServiceCaller = new CallerMock<ProcessService>(processService);
+        presenter.setProcessService(remoteProcessServiceCaller);
+        when(place.getParameter("serverTemplateId",
+                                "")).thenReturn(SERVER_TEMPLATE_ID);
+        when(place.getParameter("deploymentId",
+                                "")).thenReturn(PI_DEPLOYMENT_ID);
+        when(place.getParameter("processInstanceId",
+                                "-1")).thenReturn(PI_ID + "");
+    }
+
+    @Test
+    public void signalProcessInstancesEmptyRefTest() {
+        when(view.getSignalRefText()).thenReturn("");
+        presenter.signalProcessInstances((Arrays.asList(PI_ID)));
+
+        verify(view).setHelpText(Constants.INSTANCE.Signal_Name_Required());
+        verifyNoMoreInteractions(processService);
+    }
+
+    @Test
+    public void signalProcessInstancesTest() {
+        String signalRef = "SIGNAL_REF";
+        String eventText = "EVENT_TEXT";
+        List<Long> processInstanceIds = Arrays.asList(PI_ID,
+                                                      PI_ID2);
+
+        presenter.onStartup(place);
+        presenter.onOpen();
+        when(view.getSignalRefText()).thenReturn(signalRef);
+        when(view.getEventText()).thenReturn(eventText);
+        presenter.signalProcessInstances(processInstanceIds);
+
+        verify(view,
+               times(processInstanceIds.size())).displayNotification(anyString());
+        verify(view).displayNotification(Constants.INSTANCE.Signalling_Process_Instance() + PI_ID + " " +
+                                                 Constants.INSTANCE.Signal() + " = " + signalRef + " - " +
+                                                 Constants.INSTANCE.Signal_Data() + " = " + eventText);
+        verify(view).displayNotification(Constants.INSTANCE.Signalling_Process_Instance() + PI_ID2 + " " +
+                                                 Constants.INSTANCE.Signal() + " = " + signalRef + " - " +
+                                                 Constants.INSTANCE.Signal_Data() + " = " + eventText);
+        verify(processService).signalProcessInstances(eq(SERVER_TEMPLATE_ID),
+                                                      eq(Arrays.asList(PI_DEPLOYMENT_ID)),
+                                                      eq(processInstanceIds),
+                                                      eq(signalRef),
+                                                      eq(eventText));
+    }
+}


### PR DESCRIPTION
Check if the signal name is set and changed the abort confirm popup