### PR TITLE
[7.3.x] JBPM-6409: In taskforms data inputs (if different than outpus) should be readonly by default. (Also fixes JBPM-5742)

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
@@ -26,7 +26,6 @@ import org.jbpm.workbench.forms.service.providing.RenderingSettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
-import org.kie.workbench.common.forms.commons.shared.layout.impl.DynamicFormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.FormValuesProcessorImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors.MultipleSubFormFieldValueProcessor;
@@ -37,6 +36,7 @@ import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FieldValueProcessor;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FormValuesProcessor;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.runtime.BPMNRuntimeFormGeneratorService;
 import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
@@ -78,7 +78,8 @@ public abstract class AbstractFormProvidingEngineTest<SETTINGS extends Rendering
         when(marshallerContext.getClassloader()).thenReturn(AbstractFormProvidingEngineTest.class.getClassLoader());
 
         formSerializer = new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                          new FormModelSerializer());
+                                                          new FormModelSerializer(),
+                                                          new TestMetaDataEntryManager());
 
         List<FieldValueProcessor> processors = Arrays.asList(new SubFormFieldValueProcessor(),
                                                              new MultipleSubFormFieldValueProcessor());
@@ -88,8 +89,7 @@ public abstract class AbstractFormProvidingEngineTest<SETTINGS extends Rendering
 
         formValuesProcessor = new FormValuesProcessorImpl(fieldValueProcessors);
 
-        dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
-                                                                                                        new DynamicFormLayoutTemplateGenerator()));
+        dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(new BPMNRuntimeFormGeneratorService(new TestFieldManager()));
 
         contextManager = new BackendFormRenderingContextManagerImpl(formValuesProcessor,
                                                                     new ContextModelConstraintsExtractorImpl());

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
@@ -31,7 +31,6 @@ import org.jbpm.workbench.forms.service.providing.RenderingSettings;
 import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
-import org.kie.workbench.common.forms.commons.shared.layout.impl.DynamicFormLayoutTemplateGenerator;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.FormValuesProcessorImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.fieldProcessors.MultipleSubFormFieldValueProcessor;
@@ -42,6 +41,7 @@ import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.FormValuesProcessor;
 import org.kie.workbench.common.forms.dynamic.service.shared.impl.MapModelRenderingContext;
 import org.kie.workbench.common.forms.fields.test.TestFieldManager;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.runtime.BPMNRuntimeFormGeneratorService;
 import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
@@ -105,13 +105,13 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
         backendFormRenderingContextManager = new BackendFormRenderingContextManagerImpl(formValuesProcessor,
                                                                                         new ContextModelConstraintsExtractorImpl());
 
-        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
-                                                                          new DynamicFormLayoutTemplateGenerator());
+        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager());
 
         dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(runtimeFormGeneratorService);
 
         processor = getProcessorInstance(new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                                          new FormModelSerializer()),
+                                                                          new FormModelSerializer(),
+                                                                          new TestMetaDataEntryManager()),
                                          backendFormRenderingContextManager,
                                          dynamicBPMNFormGenerator);
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
@@ -25,6 +25,7 @@ import org.jbpm.workbench.forms.service.providing.ProcessRenderingSettings;
 import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
+import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
 import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
@@ -53,7 +54,8 @@ public class ProcessFormsValuesProcessorTest extends AbstractFormsValuesProcesso
                                                      BackendFormRenderingContextManager backendFormRenderingContextManager,
                                                      DynamicBPMNFormGenerator dynamicBPMNFormGenerator) {
         return new ProcessFormsValuesProcessor(new FormDefinitionSerializerImpl(new FieldSerializer(),
-                                                                                new FormModelSerializer()),
+                                                                                new FormModelSerializer(),
+                                                                                new TestMetaDataEntryManager()),
                                                backendFormRenderingContextManager,
                                                dynamicBPMNFormGenerator);
     }


### PR DESCRIPTION
Copy of https://github.com/kiegroup/jbpm-wb/pull/903

@cristianonicolai @jsoltes could you please take a look?

This is part of an ensemble, merge with:
https://github.com/kiegroup/kie-wb-common/pull/1187
https://github.com/kiegroup/jbpm-designer/pull/666
https://github.com/kiegroup/jbpm-wb/pull/904