### PR TITLE
AF-593+: Move uberfire-maven-utils to kie-soup.

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/pom.xml
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/pom.xml
@@ -286,12 +286,12 @@
       <artifactId>kie-soup-commons</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-maven-support</artifactId>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-maven-support</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-maven-integration</artifactId>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-maven-integration</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -503,7 +503,7 @@
             <compileSourcesArtifacts>
               <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
               <!-- UberFire -->
-              <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>
+              <compileSourcesArtifact>org.kie.soup:kie-soup-maven-support</compileSourcesArtifact>
               <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
               <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
               <compileSourcesArtifact>org.uberfire:uberfire-io</compileSourcesArtifact>

--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -143,12 +143,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-maven-support</artifactId>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-maven-support</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-maven-integration</artifactId>
+      <groupId>org.kie.soup</groupId>
+      <artifactId>kie-soup-maven-integration</artifactId>
     </dependency>
     <dependency>
       <groupId>org.uberfire</groupId>
@@ -1652,7 +1652,7 @@
             <compileSourcesArtifact>org.kie.soup:kie-soup-commons</compileSourcesArtifact>
 
             <!-- UberFire -->
-            <compileSourcesArtifact>org.uberfire:uberfire-maven-support</compileSourcesArtifact>            
+            <compileSourcesArtifact>org.kie.soup:kie-soup-maven-support</compileSourcesArtifact>            
             <compileSourcesArtifact>org.uberfire:uberfire-commons</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-nio2-model</compileSourcesArtifact>
             <compileSourcesArtifact>org.uberfire:uberfire-api</compileSourcesArtifact>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.kie.soup</groupId>
+        <artifactId>kie-soup-bom</artifactId>
+        <version>${version.org.kie}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.dashbuilder</groupId>
         <artifactId>dashbuilder-bom</artifactId>
         <version>${version.org.dashbuilder}</version>


### PR DESCRIPTION
Please see this [PR](https://github.com/kiegroup/kie-soup/pull/8) for general discussion.