### PR TITLE
JBPM-6619: Prevent build errors when deployment descriptor doesn't exist

### DIFF
--- a/jbpm-wb-integration/jbpm-wb-integration-backend/src/main/java/org/jbpm/workbench/wi/backend/server/builder/BPMPostBuildHandler.java
+++ b/jbpm-wb-integration/jbpm-wb-integration-backend/src/main/java/org/jbpm/workbench/wi/backend/server/builder/BPMPostBuildHandler.java
@@ -46,29 +46,27 @@ public class BPMPostBuildHandler implements PostBuildHandler {
 
     @Override
     public void process(BuildResults buildResults) {
-
         String rootPathString = buildResults.getParameter("RootPath");
         if (rootPathString == null) {
             return;
         }
-        try {
-            Path path = Paths.convert(ioService.get(URI.create(rootPathString + "/src/main/resources/META-INF/kie-deployment-descriptor.xml")));
-            DeploymentDescriptorModel ddModel = deploymentDescriptorService.load(path);
 
+        org.uberfire.java.nio.file.Path ddPath = ioService.get(URI.create(rootPathString + "/src/main/resources/META-INF/kie-deployment-descriptor.xml"));
+        if (ioService.exists(ddPath)) {
+            Path deploymentDescriptorPath = Paths.convert(ddPath);
+            DeploymentDescriptorModel ddModel = deploymentDescriptorService.load(deploymentDescriptorPath);
             buildResults.addParameter("RuntimeStrategy", ddModel.getRuntimeStrategy());
-        } catch (Exception e) {
-            logger.debug("Deployment descriptor not found {}", e.getMessage());
+        } else {
+            logger.debug("Deployment descriptor not found {}", ddPath);
         }
-
     }
 
     // for test purpose only
     public void setDeploymentDescriptorService(DDEditorService deploymentDescriptorService) {
         this.deploymentDescriptorService = deploymentDescriptorService;
     }
-    
+
     public void setIoService(IOService ioService) {
         this.ioService = ioService;
     }
-
 }


### PR DESCRIPTION
Hello @mswiderski , could you please take a look as the author of the original code?

The way it was implemented was causing 3 exceptions in server log every time you click build & deploy in kie-wb for a project that doesn't have any associated kie-deployment-descriptor.xml (like evaluation example project)
<details><summary>Exceptions like this</summary>
<pre>
14:48:23,536 ERROR [org.guvnor.common.services.backend.exceptions.ExceptionUtilities] (default task-13) Exception thrown: null: org.uberfire.java.nio.file.NoSuchFileException
	at org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.getFileAttributeView(JGitFileSystemProvider.java:1930)
	at org.uberfire.java.nio.file.Files.getFileAttributeView(Files.java:617)
	at org.uberfire.io.impl.IOServiceDotFileImpl.getFileAttributeView(IOServiceDotFileImpl.java:209)
	at org.guvnor.common.services.backend.metadata.MetadataServiceImpl.getMetadata(MetadataServiceImpl.java:89)
	at org.guvnor.common.services.backend.metadata.MetadataServiceImpl.getMetadata(MetadataServiceImpl.java:79)
	at org.guvnor.common.services.backend.metadata.MetadataServiceImpl$Proxy$_$$_WeldClientProxy.getMetadata(Unknown Source)
	at org.kie.workbench.common.services.backend.service.KieService.loadOverview(KieService.java:98)
	at org.kie.workbench.common.services.backend.service.KieService.loadContent(KieService.java:83)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:85)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:56)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl$Proxy$_$$_WeldClientProxy.load(Unknown Source)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler.process(BPMPostBuildHandler.java:56)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler$Proxy$_$$_WeldClientProxy.process(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.doBuildAndDeploy(BuildHelper.java:316)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.buildAndDeploy(BuildHelper.java:258)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:88)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:32)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor$Proxy$_$$_WeldClientProxy.apply(Unknown Source)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.lambda$continuePipeline$0(PipelineExecutor.java:109)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:38)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:33)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.continuePipeline(PipelineExecutor.java:94)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.execute(PipelineExecutor.java:76)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker.invokeLocalBuildPipeLine(BuildPipelineInvoker.java:84)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker$Proxy$_$$_WeldClientProxy.invokeLocalBuildPipeLine(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.invokeLocalBuildPipeLine(BuildServiceHelper.java:176)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.localBuildAndDeploy(BuildServiceHelper.java:143)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper$Proxy$_$$_WeldClientProxy.localBuildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:93)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:80)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.errai.bus.server.io.AbstractRPCMethodCallback.invokeMethodFromMessage(AbstractRPCMethodCallback.java:65)
	at org.jboss.errai.bus.server.io.ValueReplyRPCEndpointCallback.callback(ValueReplyRPCEndpointCallback.java:40)
	at org.jboss.errai.bus.server.io.RemoteServiceCallback.callback(RemoteServiceCallback.java:54)
	at org.jboss.errai.cdi.server.CDIExtensionPoints$2.callback(CDIExtensionPoints.java:448)
	at org.jboss.errai.bus.server.DeliveryPlan.deliver(DeliveryPlan.java:47)
	at org.jboss.errai.bus.server.ServerMessageBusImpl.sendGlobal(ServerMessageBusImpl.java:297)
	at org.jboss.errai.bus.server.SimpleDispatcher.dispatchGlobal(SimpleDispatcher.java:46)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:97)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:114)
	at org.jboss.errai.bus.server.servlet.DefaultBlockingServlet.doPost(DefaultBlockingServlet.java:144)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
	at io.undertow.websockets.jsr.JsrWebSocketFilter.doFilter(JsrWebSocketFilter.java:130)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecureHeadersFilter.doFilter(SecureHeadersFilter.java:110)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecurityIntegrationFilter.doFilter(SecurityIntegrationFilter.java:70)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.DisableCacheHandler.handleRequest(DisableCacheHandler.java:33)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AuthenticationConstraintHandler.handleRequest(AuthenticationConstraintHandler.java:51)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.servlet.handlers.security.ServletSecurityConstraintHandler.handleRequest(ServletSecurityConstraintHandler.java:59)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:285)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:264)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:175)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:207)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:802)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

14:48:23,538 WARN  [org.kie.workbench.common.services.backend.service.KieService] (default task-13) No metadata found for file: kie-deployment-descriptor.xml, full path [PathImpl{uri='default://master@myrepo/evaluation/src/main/resources/META-INF/kie-deployment-descriptor.xml', fileName='kie-deployment-descriptor.xml', attrs={}}]
14:48:23,552 ERROR [org.uberfire.java.nio.fs.jgit.util.GitImpl] (default task-13) Unexpected exception (1/0).: org.uberfire.java.nio.file.NoSuchFileException
	at org.uberfire.java.nio.fs.jgit.util.commands.BlobAsInputStream.execute(BlobAsInputStream.java:66)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.lambda$blobAsInputStream$2(GitImpl.java:339)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.retryIfNeeded(GitImpl.java:471)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.blobAsInputStream(GitImpl.java:336)
	at org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.newInputStream(JGitFileSystemProvider.java:883)
	at org.uberfire.java.nio.file.Files.newInputStream(Files.java:100)
	at org.uberfire.io.impl.AbstractIOService.newInputStream(AbstractIOService.java:265)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.constructContent(DDEditorServiceImpl.java:92)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.constructContent(DDEditorServiceImpl.java:56)
	at org.kie.workbench.common.services.backend.service.KieService.loadContent(KieService.java:82)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:85)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:56)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl$Proxy$_$$_WeldClientProxy.load(Unknown Source)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler.process(BPMPostBuildHandler.java:56)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler$Proxy$_$$_WeldClientProxy.process(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.doBuildAndDeploy(BuildHelper.java:316)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.buildAndDeploy(BuildHelper.java:258)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:88)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:32)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor$Proxy$_$$_WeldClientProxy.apply(Unknown Source)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.lambda$continuePipeline$0(PipelineExecutor.java:109)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:38)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:33)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.continuePipeline(PipelineExecutor.java:94)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.execute(PipelineExecutor.java:76)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker.invokeLocalBuildPipeLine(BuildPipelineInvoker.java:84)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker$Proxy$_$$_WeldClientProxy.invokeLocalBuildPipeLine(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.invokeLocalBuildPipeLine(BuildServiceHelper.java:176)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.localBuildAndDeploy(BuildServiceHelper.java:143)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper$Proxy$_$$_WeldClientProxy.localBuildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:93)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:80)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.errai.bus.server.io.AbstractRPCMethodCallback.invokeMethodFromMessage(AbstractRPCMethodCallback.java:65)
	at org.jboss.errai.bus.server.io.ValueReplyRPCEndpointCallback.callback(ValueReplyRPCEndpointCallback.java:40)
	at org.jboss.errai.bus.server.io.RemoteServiceCallback.callback(RemoteServiceCallback.java:54)
	at org.jboss.errai.cdi.server.CDIExtensionPoints$2.callback(CDIExtensionPoints.java:448)
	at org.jboss.errai.bus.server.DeliveryPlan.deliver(DeliveryPlan.java:47)
	at org.jboss.errai.bus.server.ServerMessageBusImpl.sendGlobal(ServerMessageBusImpl.java:297)
	at org.jboss.errai.bus.server.SimpleDispatcher.dispatchGlobal(SimpleDispatcher.java:46)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:97)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:114)
	at org.jboss.errai.bus.server.servlet.DefaultBlockingServlet.doPost(DefaultBlockingServlet.java:144)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
	at io.undertow.websockets.jsr.JsrWebSocketFilter.doFilter(JsrWebSocketFilter.java:130)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecureHeadersFilter.doFilter(SecureHeadersFilter.java:110)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecurityIntegrationFilter.doFilter(SecurityIntegrationFilter.java:70)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.DisableCacheHandler.handleRequest(DisableCacheHandler.java:33)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AuthenticationConstraintHandler.handleRequest(AuthenticationConstraintHandler.java:51)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.servlet.handlers.security.ServletSecurityConstraintHandler.handleRequest(ServletSecurityConstraintHandler.java:59)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:285)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:264)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:175)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:207)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:802)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

14:48:23,554 ERROR [org.guvnor.common.services.backend.exceptions.ExceptionUtilities] (default task-13) Exception thrown: null: org.uberfire.java.nio.file.NoSuchFileException
	at org.uberfire.java.nio.fs.jgit.util.commands.BlobAsInputStream.execute(BlobAsInputStream.java:66)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.lambda$blobAsInputStream$2(GitImpl.java:339)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.retryIfNeeded(GitImpl.java:471)
	at org.uberfire.java.nio.fs.jgit.util.GitImpl.blobAsInputStream(GitImpl.java:336)
	at org.uberfire.java.nio.fs.jgit.JGitFileSystemProvider.newInputStream(JGitFileSystemProvider.java:883)
	at org.uberfire.java.nio.file.Files.newInputStream(Files.java:100)
	at org.uberfire.io.impl.AbstractIOService.newInputStream(AbstractIOService.java:265)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.constructContent(DDEditorServiceImpl.java:92)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.constructContent(DDEditorServiceImpl.java:56)
	at org.kie.workbench.common.services.backend.service.KieService.loadContent(KieService.java:82)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:85)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl.load(DDEditorServiceImpl.java:56)
	at org.jbpm.workbench.wi.backend.server.dd.DDEditorServiceImpl$Proxy$_$$_WeldClientProxy.load(Unknown Source)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler.process(BPMPostBuildHandler.java:56)
	at org.jbpm.workbench.wi.backend.server.builder.BPMPostBuildHandler$Proxy$_$$_WeldClientProxy.process(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.doBuildAndDeploy(BuildHelper.java:316)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper.buildAndDeploy(BuildHelper.java:258)
	at org.kie.workbench.common.services.backend.builder.core.BuildHelper$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:88)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor.apply(LocalBuildExecConfigExecutor.java:32)
	at org.kie.workbench.common.services.backend.builder.ala.LocalBuildExecConfigExecutor$Proxy$_$$_WeldClientProxy.apply(Unknown Source)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.lambda$continuePipeline$0(PipelineExecutor.java:109)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:38)
	at org.guvnor.ala.pipeline.StageUtil$1.execute(StageUtil.java:33)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.continuePipeline(PipelineExecutor.java:94)
	at org.guvnor.ala.pipeline.execution.PipelineExecutor.execute(PipelineExecutor.java:76)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker.invokeLocalBuildPipeLine(BuildPipelineInvoker.java:84)
	at org.kie.workbench.common.services.backend.builder.ala.BuildPipelineInvoker$Proxy$_$$_WeldClientProxy.invokeLocalBuildPipeLine(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.invokeLocalBuildPipeLine(BuildServiceHelper.java:176)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper.localBuildAndDeploy(BuildServiceHelper.java:143)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceHelper$Proxy$_$$_WeldClientProxy.localBuildAndDeploy(Unknown Source)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:93)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl.buildAndDeploy(BuildServiceImpl.java:80)
	at org.kie.workbench.common.services.backend.builder.service.BuildServiceImpl$Proxy$_$$_WeldClientProxy.buildAndDeploy(Unknown Source)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.jboss.errai.bus.server.io.AbstractRPCMethodCallback.invokeMethodFromMessage(AbstractRPCMethodCallback.java:65)
	at org.jboss.errai.bus.server.io.ValueReplyRPCEndpointCallback.callback(ValueReplyRPCEndpointCallback.java:40)
	at org.jboss.errai.bus.server.io.RemoteServiceCallback.callback(RemoteServiceCallback.java:54)
	at org.jboss.errai.cdi.server.CDIExtensionPoints$2.callback(CDIExtensionPoints.java:448)
	at org.jboss.errai.bus.server.DeliveryPlan.deliver(DeliveryPlan.java:47)
	at org.jboss.errai.bus.server.ServerMessageBusImpl.sendGlobal(ServerMessageBusImpl.java:297)
	at org.jboss.errai.bus.server.SimpleDispatcher.dispatchGlobal(SimpleDispatcher.java:46)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:97)
	at org.jboss.errai.bus.server.service.ErraiServiceImpl.store(ErraiServiceImpl.java:114)
	at org.jboss.errai.bus.server.servlet.DefaultBlockingServlet.doPost(DefaultBlockingServlet.java:144)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:707)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
	at io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:85)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:129)
	at io.undertow.websockets.jsr.JsrWebSocketFilter.doFilter(JsrWebSocketFilter.java:130)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecureHeadersFilter.doFilter(SecureHeadersFilter.java:110)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at org.uberfire.ext.security.server.SecurityIntegrationFilter.doFilter(SecurityIntegrationFilter.java:70)
	at io.undertow.servlet.core.ManagedFilter.doFilter(ManagedFilter.java:61)
	at io.undertow.servlet.handlers.FilterHandler$FilterChainImpl.doFilter(FilterHandler.java:131)
	at io.undertow.servlet.handlers.FilterHandler.handleRequest(FilterHandler.java:84)
	at io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.extension.undertow.security.SecurityContextAssociationHandler.handleRequest(SecurityContextAssociationHandler.java:78)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:131)
	at io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.server.handlers.DisableCacheHandler.handleRequest(DisableCacheHandler.java:33)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.security.handlers.AuthenticationConstraintHandler.handleRequest(AuthenticationConstraintHandler.java:51)
	at io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.servlet.handlers.security.ServletSecurityConstraintHandler.handleRequest(ServletSecurityConstraintHandler.java:59)
	at io.undertow.security.handlers.AuthenticationMechanismsHandler.handleRequest(AuthenticationMechanismsHandler.java:60)
	at io.undertow.servlet.handlers.security.CachedAuthenticatedSessionHandler.handleRequest(CachedAuthenticatedSessionHandler.java:77)
	at io.undertow.security.handlers.NotificationReceiverHandler.handleRequest(NotificationReceiverHandler.java:50)
	at io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:61)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:285)
	at io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:264)
	at io.undertow.servlet.handlers.ServletInitialHandler.access$000(ServletInitialHandler.java:81)
	at io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:175)
	at io.undertow.server.Connectors.executeRootHandler(Connectors.java:207)
	at io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:802)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)

</pre>
</details>

My proposed fix first checks for existence of the file before calling the load on DDEditorService.