### PR TITLE
[JBPM-6626] Enhance Job Details tests

### DIFF
--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/jobdetails/JobDetailsPresenter.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/jobdetails/JobDetailsPresenter.java
@@ -15,6 +15,7 @@
  */
 package org.jbpm.workbench.es.client.editors.jobdetails;
 
+import java.util.List;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
@@ -23,7 +24,9 @@ import javax.inject.Inject;
 import org.jboss.errai.common.client.api.Caller;
 import org.jbpm.workbench.es.client.editors.events.JobSelectedEvent;
 import org.jbpm.workbench.es.client.i18n.Constants;
+import org.jbpm.workbench.es.model.ErrorSummary;
 import org.jbpm.workbench.es.model.RequestDetails;
+import org.jbpm.workbench.es.model.RequestParameterSummary;
 import org.jbpm.workbench.es.model.RequestSummary;
 import org.jbpm.workbench.es.service.ExecutorService;
 import org.uberfire.client.annotations.DefaultPosition;
@@ -104,9 +107,16 @@ public class JobDetailsPresenter implements RefreshMenuBuilder.SupportsRefresh {
                                             final Long jobId) {
         executorServices.call(
                 (RequestDetails requestDetails) -> {
-                    view.setValue(requestDetails);
-                    changeTitleWidgetEvent.fire(new ChangeTitleWidgetEvent(this.place,
-                                                                           getJobDetailTitle(requestDetails.getRequest())));
+                    if (requestDetails != null) {
+                        view.setBasicDetails(requestDetails.getRequest());
+                        view.setParameters(requestDetails.getParams());
+                        List<ErrorSummary> errors = requestDetails.getErrors();
+                        if (errors != null && errors.size() > 0) {
+                            view.setErrors(errors);
+                        }
+                        changeTitleWidgetEvent.fire(new ChangeTitleWidgetEvent(this.place,
+                                                                               getJobDetailTitle(requestDetails.getRequest())));
+                    }
                 })
                 .getRequestDetails(serverTemplateId,
                                    deploymentId,
@@ -135,6 +145,10 @@ public class JobDetailsPresenter implements RefreshMenuBuilder.SupportsRefresh {
 
     public interface JobDetailsView extends UberElement<JobDetailsPresenter> {
 
-        void setValue(RequestDetails requestDetails);
+        void setBasicDetails(RequestSummary requestSummary);
+
+        void setParameters(List<RequestParameterSummary> requestParameterSummaries);
+
+        void setErrors(List<ErrorSummary> errors);
     }
 }

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/jobdetails/JobDetailsViewImpl.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/jobdetails/JobDetailsViewImpl.java
@@ -31,8 +31,8 @@ import org.jboss.errai.ui.shared.api.annotations.Bundle;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.jbpm.workbench.es.model.ErrorSummary;
-import org.jbpm.workbench.es.model.RequestDetails;
 import org.jbpm.workbench.es.model.RequestParameterSummary;
+import org.jbpm.workbench.es.model.RequestSummary;
 import org.uberfire.client.mvp.PlaceManager;
 
 import static org.jboss.errai.common.client.dom.DOMUtil.removeCSSClass;
@@ -81,31 +81,30 @@ public class JobDetailsViewImpl implements JobDetailsPresenter.JobDetailsView {
     }
 
     @Override
-    public void setValue(RequestDetails jobDetails) {
-        basicJobDetails.setValue(jobDetails.getRequest());
-
-        setJobParameters(jobDetails.getParams());
-        List<ErrorSummary> errors = jobDetails.getErrors();
-        if (jobDetails.getErrors() != null && errors.size() > 0) {
-            errorControlGroup.setHidden(false);
-            String textAreaContent = "";
-            for (ErrorSummary error : errors) {
-                textAreaContent += error.getMessage() + "\n" +
-                        error.getStacktrace() + "\n\n";
-            }
-            this.jobErrorTextArea.setText(textAreaContent);
-        } else {
-            errorControlGroup.setHidden(true);
-        }
+    public void setBasicDetails(RequestSummary requestSummary) {
+        basicJobDetails.setValue(requestSummary);
+        errorControlGroup.setHidden(true);
     }
 
-    public void setJobParameters(final List<RequestParameterSummary> requestParameterSummaries) {
+    @Override
+    public void setParameters(List<RequestParameterSummary> requestParameterSummaries) {
         if (requestParameterSummaries.size() > 0) {
             removeCSSClass(paramsFormGroup,
                            "hidden");
         }
 
         jobParameterList.setModel(requestParameterSummaries);
+    }
+
+    @Override
+    public void setErrors(List<ErrorSummary> errors) {
+        errorControlGroup.setHidden(false);
+        String textAreaContent = "";
+        for (ErrorSummary error : errors) {
+            textAreaContent += error.getMessage() + "\n" +
+                    error.getStacktrace() + "\n\n";
+        }
+        this.jobErrorTextArea.setText(textAreaContent);
     }
 
     @Override

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/test/java/org/jbpm/workbench/es/client/editors/requestlist/RequestListPresenterTest.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/test/java/org/jbpm/workbench/es/client/editors/requestlist/RequestListPresenterTest.java
@@ -47,6 +47,7 @@ import org.uberfire.mvp.PlaceRequest;
 import org.uberfire.mvp.impl.DefaultPlaceRequest;
 
 import static org.dashbuilder.dataset.sort.SortOrder.ASCENDING;
+import static org.jbpm.workbench.es.client.editors.util.JobUtils.createRequestSummary;
 import static org.jbpm.workbench.es.model.RequestDataSetConstants.*;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -295,16 +296,7 @@ public class RequestListPresenterTest {
 
     @Test
     public void testJobSelectionWithDetailsClosed() {
-        Long jobId = 1L;
-        String deploymentId = "evaluation.1.0.1";
-        String processName = "testProcessName";
-        String processInstanceDescription = "testProcessInstDescription";
-        Long processInstanceId = 2L;
-        RequestSummary job = createTestRequestSummary(jobId,
-                                                      deploymentId,
-                                                      processName,
-                                                      processInstanceId,
-                                                      processInstanceDescription);
+        RequestSummary job = createRequestSummary();
         boolean closed = true;
         when(placeManager.getStatus(any(DefaultPlaceRequest.class))).thenReturn(PlaceStatus.CLOSE);
         presenter.selectJob(job,
@@ -314,22 +306,13 @@ public class RequestListPresenterTest {
         final ArgumentCaptor<JobSelectedEvent> captor = ArgumentCaptor.forClass(JobSelectedEvent.class);
         verify(jobSelectedEventMock).fire(captor.capture());
         assertJobSelectedEventContent(captor.getValue(),
-                                      deploymentId,
-                                      jobId);
+                                      job.getDeploymentId(),
+                                      job.getId());
     }
 
     @Test
     public void testJobSelectionWithDetailsOpen() {
-        Long jobId = 1L;
-        String deploymentId = "evaluation.1.0.1";
-        String processName = "testProcessName";
-        String processInstanceDescription = "testProcessInstDescription";
-        Long processInstanceId = 2L;
-        RequestSummary job = createTestRequestSummary(jobId,
-                                                      deploymentId,
-                                                      processName,
-                                                      processInstanceId,
-                                                      processInstanceDescription);
+        RequestSummary job = createRequestSummary();
         boolean closed = false;
         when(placeManager.getStatus(any(DefaultPlaceRequest.class))).thenReturn(PlaceStatus.OPEN);
         presenter.selectJob(job,
@@ -341,50 +324,23 @@ public class RequestListPresenterTest {
         final ArgumentCaptor<JobSelectedEvent> captor = ArgumentCaptor.forClass(JobSelectedEvent.class);
         verify(jobSelectedEventMock).fire(captor.capture());
         assertJobSelectedEventContent(captor.getValue(),
-                                      deploymentId,
-                                      jobId);
+                                      job.getDeploymentId(),
+                                      job.getId());
     }
 
     @Test
     public void testCloseDetails() {
-        Long jobId = 1L;
-        String deploymentId = "evaluation.1.0.1";
-        String processName = "testProcessName";
-        String processInstanceDescription = "testProcessInstDescription";
-        Long processInstanceId = 2L;
-        RequestSummary job = createTestRequestSummary(jobId,
-                                                      deploymentId,
-                                                      processName,
-                                                      processInstanceId,
-                                                      processInstanceDescription);
+        RequestSummary job = createRequestSummary();
         boolean closed = true;
         when(placeManager.getStatus(any(DefaultPlaceRequest.class))).thenReturn(PlaceStatus.OPEN);
         presenter.selectJob(job,
                             closed);
 
         verify(placeManager,
-               never()).goTo(any(PlaceRequest.class));
+               never()).goTo(anyString());
         verify(jobSelectedEventMock,
                never()).fire(any());
-    }
-
-    private RequestSummary createTestRequestSummary(Long jobId,
-                                                    String deploymentId,
-                                                    String processName,
-                                                    Long processInstanceId,
-                                                    String processInstanceDescription) {
-        return new RequestSummary(jobId,
-                                  new Date(),
-                                  RequestStatus.QUEUED,
-                                  "commandName",
-                                  "Message",
-                                  "key",
-                                  1,
-                                  0,
-                                  processName,
-                                  processInstanceId,
-                                  processInstanceDescription,
-                                  deploymentId);
+        verify(placeManager).closePlace(JobDetailsPresenter.SCREEN_ID);
     }
 
     private void assertJobSelectedEventContent(JobSelectedEvent event,

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/test/java/org/jbpm/workbench/es/client/editors/util/JobUtils.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/test/java/org/jbpm/workbench/es/client/editors/util/JobUtils.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.es.client.editors.util;
+
+import java.util.Date;
+
+import org.jbpm.workbench.es.model.ErrorSummary;
+import org.jbpm.workbench.es.model.RequestParameterSummary;
+import org.jbpm.workbench.es.model.RequestSummary;
+import org.jbpm.workbench.es.util.RequestStatus;
+
+public class JobUtils {
+
+    private static final Long JOB_ID = 1L;
+    private static final Long PROCESS_INSTANCE_ID = 2L;
+
+    public static RequestSummary createRequestSummary() {
+        return createRequestSummary(JOB_ID,
+                                    "businessKey",
+                                    RequestStatus.QUEUED);
+    }
+
+    public static RequestSummary createRequestSummary(RequestStatus status) {
+        return createRequestSummary(JOB_ID,
+                                    "businessKey",
+                                    status);
+    }
+
+    public static RequestSummary createRequestSummary(Long jobId,
+                                                      String businessKey,
+                                                      RequestStatus status) {
+        return new RequestSummary(jobId,
+                                  new Date(),
+                                  status,
+                                  "commandName",
+                                  "Message",
+                                  businessKey,
+                                  1,
+                                  0,
+                                  "testProcessName",
+                                  PROCESS_INSTANCE_ID,
+                                  "testProcessInstanceDescription",
+                                  "evaluation.1.0.1");
+    }
+
+    public static ErrorSummary createErrorSummary() {
+        return new ErrorSummary(3L,
+                                new Date(),
+                                "errorMessage",
+                                "errorStacktrace",
+                                JOB_ID);
+    }
+
+    public static RequestParameterSummary createRequestParameterSummary() {
+        return new RequestParameterSummary("processInstanceId",
+                                           Long.toString(PROCESS_INSTANCE_ID));
+    }
+}


### PR DESCRIPTION
@cristianonicolai @nmirasch Enhanced unit tests as far as they could go, as I'm not planning to add any Selenium or integration tests in the future for Job Details.
Also, I introduced a small fix for NPE in case of clicking on a job which is still being shown in the Jobs list, but has already been deleted in the background by executor's log clean-up command (named test ```testStaleJobSelected```, but I'm open to suggestions for a maybe clearer name :))