### PR TITLE
JBPM-6664 - CannotResolveClassException thrown when accessing active …

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/main/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImpl.java
@@ -150,7 +150,7 @@ public class RemoteCaseManagementServiceImpl implements CaseManagementService {
                                                final String caseId) {
         return ofNullable(client.getCaseInstance(containerId,
                                                  caseId,
-                                                 true,
+                                                 false,
                                                  true,
                                                  true,
                                                  true))

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImplTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/src/test/java/org/jbpm/workbench/cm/backend/server/RemoteCaseManagementServiceImplTest.java
@@ -269,7 +269,7 @@ public class RemoteCaseManagementServiceImplTest {
         final CaseInstance ci = createTestInstance(caseId);
         when(clientMock.getCaseInstance(ci.getContainerId(),
                                         ci.getCaseId(),
-                                        true,
+                                        false,
                                         true,
                                         true,
                                         true))
@@ -286,7 +286,7 @@ public class RemoteCaseManagementServiceImplTest {
     public void getCaseInstance_whenClientReturnsNull() {
         when(clientMock.getCaseInstance(containerId,
                                         caseId,
-                                        true,
+                                        false,
                                         true,
                                         true,
                                         true))
@@ -597,7 +597,7 @@ public class RemoteCaseManagementServiceImplTest {
 
         when(clientMock.getCaseInstance(ci.getContainerId(),
                                         ci.getCaseId(),
-                                        true,
+                                        false,
                                         true,
                                         true,
                                         true))
@@ -764,7 +764,7 @@ public class RemoteCaseManagementServiceImplTest {
 
         when(clientMock.getCaseInstance(ci.getContainerId(),
                                         ci.getCaseId(),
-                                        true,
+                                        false,
                                         true,
                                         true,
                                         true))


### PR DESCRIPTION
…case

@cristianonicolai @bsremac this is in general a quick fix to not load case data as show case app does not really use that so there is no need to load it.

When it comes to long term solution, we need to have kie server client per containers deployed to kie server because data model that is inside kjar won't be found by showcase. Same thing was required in workbench and when you look at this in workbench you can actually work with the Survey class there.

So I suggest to merge this in for 7.5 community and maybe later on look for more advanced cases... though not sure this needs to be done since the case app is showcase only.