### PR TITLE
[JBPM-6703] Case owner input allows spaces and comma separated list of entries

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/newcase/NewCaseInstanceViewImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/newcase/NewCaseInstanceViewImpl.java
@@ -197,28 +197,24 @@ public class NewCaseInstanceViewImpl extends AbstractView<NewCaseInstancePresent
     private boolean validateForm() {
         clearErrorMessages();
 
-        boolean valid = true;
+        boolean validCase = true;
 
         if (isNullOrEmpty(caseTemplatesList.getValue())) {
             caseTemplatesList.getElement().focus();
             definitionNameHelp.setTextContent(translationService.format(Constants.PLEASE_SELECT_CASE));
             caseDefinitionNameGroup.setValidationState(ValidationState.ERROR);
-            valid = false;
+            validCase = false;
         }
 
-        if (isNullOrEmpty(ownerNameInput.getValue())) {
-            ownerNameInput.focus();
-            ownerNameHelp.setTextContent(translationService.format(Constants.PLEASE_PROVIDE_CASE_OWNER));
-            ownerNameGroup.setValidationState(ValidationState.ERROR);
-            valid = false;
-        }
+        boolean validOwner = presenter.validateCaseOwnerAssignment(ownerNameInput.getValue());
 
-        if (valid) {
+        boolean isFormValid = validCase && validOwner;
+        if (isFormValid) {
             caseDefinitionNameGroup.setValidationState(ValidationState.SUCCESS);
             ownerNameGroup.setValidationState(ValidationState.SUCCESS);
         }
 
-        return valid;
+        return isFormValid;
     }
 
     @Override
@@ -230,6 +226,13 @@ public class NewCaseInstanceViewImpl extends AbstractView<NewCaseInstancePresent
         notification.setMessage(messages);
         removeCSSClass(notification.getElement(),
                        "hidden");
+    }
+
+    @Override
+    public void showCaseOwnerError(String message) {
+        ownerNameInput.focus();
+        ownerNameHelp.setTextContent(message);
+        ownerNameGroup.setValidationState(ValidationState.ERROR);
     }
 
     @Override


### PR DESCRIPTION
@cristianonicolai @nmirasch Made case owner input validation more strict in order to prevent issues occurring after a new case instance is started but has an invalid case owner format.
The role cardinality validation and proper input formatting is aligned with how we handle all other case roles defined in the case definition.
The owner role is limited to only one assignment until we decide to relax that constraint in the future.