### PR TITLE
[JBPM-6783] Jobs: Test new job dialog

### DIFF
--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractScreenListPresenter.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractScreenListPresenter.java
@@ -78,7 +78,7 @@ public abstract class AbstractScreenListPresenter<T> extends AbstractListPresent
         return selectedServerTemplate;
     }
 
-    protected void setSelectedServerTemplate(final String selectedServerTemplate) {
+    public void setSelectedServerTemplate(final String selectedServerTemplate) {
         final String newServerTemplate = Optional.ofNullable(selectedServerTemplate).orElse("").trim();
         if (this.selectedServerTemplate.equals(newServerTemplate) == false) {
             this.selectedServerTemplate = newServerTemplate;

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/quicknewjob/NewJobPresenter.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/quicknewjob/NewJobPresenter.java
@@ -73,8 +73,11 @@ public class NewJobPresenter {
             Map<String, String> jobCtxMap = new HashMap<String, String>();
             if (parameters != null) {
                 for (RequestParameterSummary param : parameters) {
-                    jobCtxMap.put(param.getKey(),
-                                  param.getValue());
+                    if (!(constants.ClickToEdit().equals(param.getKey()) ||
+                            constants.ClickToEdit().equals(param.getValue()))) {
+                        jobCtxMap.put(param.getKey(),
+                                      param.getValue());
+                    }
                 }
             }
             jobCtxMap.put(RequestDataSetConstants.COLUMN_RETRIES,
@@ -106,11 +109,12 @@ public class NewJobPresenter {
         }
     }
 
-    protected boolean validateForm(String jobName,
-                                   String jobType,
-                                   String jobRetries) {
+    private boolean validateForm(String jobName,
+                                 String jobType,
+                                 String jobRetries) {
         boolean valid = true;
         view.cleanErrorMessages();
+
         if (jobName.isEmpty()) {
             view.showEmptyNameErrorMessage();
             valid = false;
@@ -133,7 +137,8 @@ public class NewJobPresenter {
         String message = "";
         if (throwable.getMessage() != null) {
             message = throwable.getMessage();
-        } else if (throwable.getCause() != null && throwable.getCause().getMessage() != null) {
+        } else if (throwable.getCause() != null &&
+                     throwable.getCause().getMessage() != null) {
             message = throwable.getCause().getMessage();
         }
         return message.contains("Invalid command type");

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/quicknewjob/NewJobViewImpl.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/quicknewjob/NewJobViewImpl.java
@@ -45,6 +45,7 @@ import org.jboss.errai.common.client.dom.NumberInput;
 import org.jboss.errai.common.client.dom.RadioInput;
 import org.jboss.errai.common.client.dom.Span;
 import org.jboss.errai.common.client.dom.TextInput;
+import org.jboss.errai.common.client.dom.ListItem;
 import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
@@ -78,8 +79,16 @@ public class NewJobViewImpl implements NewJobPresenter.NewJobView,
     private final Constants constants = Constants.INSTANCE;
 
     @Inject
+    @DataField("basic-tab")
+    ListItem basicTab;
+
+    @Inject
     @DataField("basic-pane")
     private Div basicPane;
+
+    @Inject
+    @DataField("advanced-tab")
+    ListItem advancedTab;
 
     @Inject
     @DataField("advanced-pane")
@@ -269,7 +278,16 @@ public class NewJobViewImpl implements NewJobPresenter.NewJobView,
 
     @Override
     public void showBasicPane() {
+        addCSSClass(basicTab, 
+                    "active");
+        addCSSClass(basicPane,
+                    "active");
         basicPane.setHidden(false);
+
+        removeCSSClass(advancedTab,
+                       "active");
+        removeCSSClass(advancedPane,
+                       "active");
         advancedPane.setHidden(true);
     }
 
@@ -348,8 +366,7 @@ public class NewJobViewImpl implements NewJobPresenter.NewJobView,
                                                                                 myParametersGrid,
                                                                                 paramKeyColumn));
 
-        Column<RequestParameterSummary, String> paramValueColumn = new Column<RequestParameterSummary, String>(
-                new EditTextCell()) {
+        Column<RequestParameterSummary, String> paramValueColumn = new Column<RequestParameterSummary, String>(new EditTextCell()) {
             @Override
             public String getValue(RequestParameterSummary rowObject) {
                 return rowObject.getValue();
@@ -427,10 +444,10 @@ public class NewJobViewImpl implements NewJobPresenter.NewJobView,
     @EventHandler("start")
     public void onCreateClick(final @ForEvent("click") MouseEvent event) {
         presenter.createJob(jobNameInput.getValue(),
-                                selectedDate,
-                                jobTypeInput.getValue(),
-                                jobRetriesInput.getValue(),
-                                dataProvider.getList());
+                            selectedDate,
+                            jobTypeInput.getValue(),
+                            jobRetriesInput.getValue(),
+                            dataProvider.getList());
     }
 
     @EventHandler("cancel")

--- a/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/requestlist/RequestListPresenter.java
+++ b/jbpm-wb-executor-service/jbpm-wb-executor-service-client/src/main/java/org/jbpm/workbench/es/client/editors/requestlist/RequestListPresenter.java
@@ -77,6 +77,10 @@ public class RequestListPresenter extends AbstractMultiGridPresenter<RequestSumm
 
     private Constants constants = Constants.INSTANCE;
 
+    private NewJobPresenter newJobPresenter;
+
+    private Command newJobCommand;
+
     @Inject
     private Caller<ExecutorService> executorServices;
 
@@ -84,13 +88,15 @@ public class RequestListPresenter extends AbstractMultiGridPresenter<RequestSumm
     private Event<RequestChangedEvent> requestChangedEvent;
 
     @Inject
-    private NewJobPresenter newJobPresenter;
-
-    @Inject
     private ErrorPopupPresenter errorPopup;
 
     @Inject
     private Event<JobSelectedEvent> jobSelectedEvent;
+
+    @Inject
+    protected void setNewJobPresenter(NewJobPresenter newJobPresenter) {
+        this.newJobPresenter = newJobPresenter;
+    }
 
     public RequestListPresenter() {
         super();
@@ -114,6 +120,10 @@ public class RequestListPresenter extends AbstractMultiGridPresenter<RequestSumm
     @WorkbenchPartTitle
     public String getTitle() {
         return constants.Jobs();
+    }
+
+    public Command getNewJobCommand() {
+        return newJobCommand;
     }
 
     @Override
@@ -235,19 +245,20 @@ public class RequestListPresenter extends AbstractMultiGridPresenter<RequestSumm
 
     @WorkbenchMenu
     public Menus getMenus() {
+        newJobCommand = new Command() {
+                            @Override
+                            public void execute() {
+                                final String selectedServerTemplate = getSelectedServerTemplate();
+                                if (selectedServerTemplate == null || selectedServerTemplate.trim().isEmpty()) {
+                                    view.displayNotification(constants.SelectServerTemplate());
+                                } else {
+                                    newJobPresenter.openNewJobDialog(selectedServerTemplate);
+                                }
+                            }
+        };
         return MenuFactory
                 .newTopLevelMenu(constants.New_Job())
-                .respondsWith(new Command() {
-                    @Override
-                    public void execute() {
-                        final String selectedServerTemplate = getSelectedServerTemplate();
-                        if (selectedServerTemplate == null || selectedServerTemplate.trim().isEmpty()) {
-                            view.displayNotification(constants.SelectServerTemplate());
-                        } else {
-                            newJobPresenter.openNewJobDialog(selectedServerTemplate);
-                        }
-                    }
-                })
+                .respondsWith(newJobCommand)
                 .endMenu()
                 .newTopLevelCustomMenu(serverTemplateSelectorMenuBuilder)
                 .endMenu()


### PR DESCRIPTION
@cristianonicolai @nmirasch Added a couple of more tests and did a small re-factoring of the existing tests.
Two bugs fixed:
1. On new job dialog re-open, the basic tab/pane is not set by default, although I could see in the code that was the intended behavior.
2.  Bogus additional job parameters entries (added via Advanced pane) i.e. those which contain _Click to Edit_ in place of parameter key/value are sent to Kie Server and as a consequence shown in _Job Details_ panel. 