### PR TITLE
BAPL-764-migration-tool: Provide migration path from old Form Modeler to the new one

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-backend/pom.xml
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/pom.xml
@@ -104,7 +104,7 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
-      <artifactId>kie-wb-common-forms-serialization</artifactId>
+      <artifactId>kie-wb-common-forms-backend-services</artifactId>
     </dependency>
 
     <dependency>

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/KieWorkbenchFormsValuesProcessor.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/KieWorkbenchFormsValuesProcessor.java
@@ -35,7 +35,7 @@ import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.util.BPMNVariableUtils;
 import org.kie.workbench.common.forms.model.FormDefinition;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.slf4j.Logger;
 
 public abstract class KieWorkbenchFormsValuesProcessor<T extends RenderingSettings> {

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessor.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessor.java
@@ -33,8 +33,8 @@ import org.kie.workbench.common.forms.jbpm.service.bpmn.util.BPMNVariableUtils;
 import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.impl.meta.entries.FieldTypeEntry;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessor.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessor.java
@@ -39,8 +39,8 @@ import org.kie.workbench.common.forms.model.FormDefinition;
 import org.kie.workbench.common.forms.model.ModelProperty;
 import org.kie.workbench.common.forms.model.impl.meta.entries.FieldReadOnlyEntry;
 import org.kie.workbench.common.forms.model.impl.meta.entries.FieldTypeEntry;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
 import org.kie.workbench.common.forms.service.backend.util.ModelPropertiesGenerator;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImplTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImplTest.java
@@ -59,10 +59,10 @@ import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.ru
 import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
 import org.kie.workbench.common.forms.model.FieldDefinition;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
-import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormModelSerializer;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
@@ -42,10 +42,10 @@ import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.runtime.BPMNRuntimeFormGeneratorService;
 import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
-import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormModelSerializer;
 import org.mockito.Mock;
 
 import static junit.framework.Assert.assertEquals;

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
@@ -48,10 +48,11 @@ import org.kie.workbench.common.forms.jbpm.server.service.formGeneration.impl.ru
 import org.kie.workbench.common.forms.jbpm.server.service.impl.DynamicBPMNFormGeneratorImpl;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
 import org.kie.workbench.common.forms.model.FieldDefinition;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
-import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormModelSerializer;
 import org.mockito.Mock;
 
 import static org.junit.Assert.*;

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
@@ -27,10 +27,10 @@ import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FieldSerializer;
-import org.kie.workbench.common.forms.serialization.impl.FormDefinitionSerializerImpl;
-import org.kie.workbench.common.forms.serialization.impl.FormModelSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FieldSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormDefinitionSerializerImpl;
+import org.kie.workbench.common.forms.services.backend.serialization.impl.FormModelSerializer;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
@@ -31,7 +31,7 @@ import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/process/AbstractStartProcessFormTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/process/AbstractStartProcessFormTest.java
@@ -34,7 +34,7 @@ import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
 import org.junit.Test;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertNotNull;

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/task/AbstractTaskFormProvidingTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/task/AbstractTaskFormProvidingTest.java
@@ -35,7 +35,7 @@ import org.jbpm.workbench.forms.service.providing.model.TaskDefinition;
 import org.junit.Test;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.jbpm.service.bpmn.DynamicBPMNFormGenerator;
-import org.kie.workbench.common.forms.serialization.FormDefinitionSerializer;
+import org.kie.workbench.common.forms.services.backend.serialization.FormDefinitionSerializer;
 import org.mockito.Mock;
 
 import static junit.framework.TestCase.assertNotNull;

--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1082,7 +1082,7 @@
 
     <dependency>
       <groupId>org.kie.workbench.forms</groupId>
-      <artifactId>kie-wb-common-forms-serialization</artifactId>
+      <artifactId>kie-wb-common-forms-backend-services</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
There has been some packages changes.

@cristianonicolai could you please take a look?

https://github.com/kiegroup/kie-wb-distributions/pull/704

This PR is part of an ensemble, merge with:

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/720
https://github.com/kiegroup/kie-wb-common/pull/1492
https://github.com/kiegroup/jbpm-designer/pull/754
https://github.com/kiegroup/jbpm-wb/pull/993
https://github.com/kiegroup/kie-wb-distributions/pull/704