### PR TITLE
JBPM-5649: Removed dependency to Stunner's default backend services.

### DIFF
--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1408,12 +1408,6 @@
 
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
-      <artifactId>kie-wb-common-stunner-backend</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.kie.workbench.stunner</groupId>
       <artifactId>kie-wb-common-stunner-client-common</artifactId>
       <scope>provided</scope>
     </dependency>


### PR DESCRIPTION
Hey @hasys @jomarko 

This removes the use on the showcase of some unused services from Stunner. 

It **depends on** https://github.com/kiegroup/kie-wb-common/pull/1509

Thanks!