### PR TITLE
[JBPM-7115] Case audit: Review tests

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/model/CaseActionSummary.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-api/src/main/java/org/jbpm/workbench/cm/model/CaseActionSummary.java
@@ -24,6 +24,9 @@ import org.jboss.errai.databinding.client.api.Bindable;
 import org.jbpm.workbench.cm.util.CaseActionStatus;
 import org.jbpm.workbench.cm.util.CaseActionType;
 
+import static org.jbpm.workbench.cm.util.CaseActionType.DYNAMIC_SUBPROCESS_TASK;
+import static org.jbpm.workbench.cm.util.CaseActionType.DYNAMIC_USER_TASK;
+
 @Bindable
 @Portable
 public class CaseActionSummary {
@@ -117,8 +120,13 @@ public class CaseActionSummary {
             return false;
         }
         CaseActionSummary that = (CaseActionSummary) o;
-        return Objects.equals(id,
-                              that.getId());
+        if (this.actionType == DYNAMIC_USER_TASK || this.actionType == DYNAMIC_SUBPROCESS_TASK) {
+            return Objects.equals(name,
+                                  that.getName());
+        } else {
+            return Objects.equals(id,
+                                  that.getId());
+        }
     }
 
     @Override

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/pom.xml
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-backend/pom.xml
@@ -72,6 +72,11 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionItemView.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionItemView.java
@@ -33,8 +33,6 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.jbpm.workbench.cm.client.util.AbstractView;
 import org.jbpm.workbench.cm.client.util.DateConverter;
-import org.jbpm.workbench.cm.util.CaseActionStatus;
-import org.jbpm.workbench.cm.util.CaseActionType;
 import org.jbpm.workbench.cm.model.CaseActionSummary;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
@@ -57,24 +55,24 @@ public class CaseActionItemView extends AbstractView<CaseActionsPresenter> imple
 
     @Inject
     @DataField("action-info")
-    Span actionInfo;
+    private Span actionInfo;
 
     @Inject
     @DataField("action-createdOn")
     @Bound(converter = DateConverter.class)
-    Span createdOn;
+    private Span createdOn;
 
     @Inject
     @DataField("list-group-item")
-    Div listGroupItem;
+    private Div listGroupItem;
 
     @Inject
     @DataField("actions-dropdown")
-    Div actions;
+    private Div actions;
 
     @Inject
     @DataField("actions-items")
-    UnorderedList actionsItems;
+    private UnorderedList actionsItems;
 
     @Inject
     @AutoBound
@@ -93,36 +91,13 @@ public class CaseActionItemView extends AbstractView<CaseActionsPresenter> imple
     @Override
     public void setValue(final CaseActionSummary model) {
         this.caseActionSummary.setModel(model);
+
         removeCSSClass(actions,
                        "dropup");
-
-        final CaseActionType actionType = model.getActionType();
-        final CaseActionStatus actionStatus = model.getActionStatus();
-
-        switch (actionStatus) {
-            case AVAILABLE: {
-                prepareAction(model,
-                              actionType);
-                break;
-            }
-            case IN_PROGRESS: {
-                removeCSSClass(createdOn,
-                               "hidden");
-                if (!isNullOrEmpty(model.getActualOwner())) {
-                    actionInfo.setTextContent(" (" + model.getActualOwner() + ") ");
-                }
-                break;
-            }
-            case COMPLETED: {
-                removeCSSClass(createdOn,
-                               "hidden");
-            }
-        }
     }
 
-    private void prepareAction(CaseActionSummary model,
-                               CaseActionType actionType) {
-        switch (actionType) {
+    void prepareAction(CaseActionSummary model) {
+        switch (model.getActionType()) {
             case AD_HOC_TASK: {
                 if (isNullOrEmpty(model.getStageId())) {
                     actionInfo.setTextContent(translationService.format(AVAILABLE_IN) + ": " + translationService.format(CASE));
@@ -158,7 +133,7 @@ public class CaseActionItemView extends AbstractView<CaseActionsPresenter> imple
 
                     @Override
                     public void execute() {
-                        presenter.showDynamicAction(actionType);
+                        presenter.showDynamicAction(model.getActionType());
                     }
                 });
             }
@@ -176,6 +151,15 @@ public class CaseActionItemView extends AbstractView<CaseActionsPresenter> imple
         final HTMLElement li = getDocument().createElement("li");
         li.appendChild(a);
         actionsItems.appendChild(li);
+    }
+
+    public void addCreationDate() {
+        removeCSSClass(createdOn,
+                       "hidden");
+    }
+
+    public void addActionOwner(final String owner) {
+        actionInfo.setTextContent(" (" + owner + ") ");
     }
 
     public void setLastElementStyle() {

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsListViewImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsListViewImpl.java
@@ -18,6 +18,7 @@ package org.jbpm.workbench.cm.client.actions;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import javax.enterprise.context.Dependent;
 import javax.inject.Inject;
 
@@ -34,6 +35,7 @@ import org.jbpm.workbench.cm.client.pagination.PaginationViewImpl;
 import org.jbpm.workbench.cm.client.util.AbstractView;
 import org.jbpm.workbench.cm.model.CaseActionSummary;
 
+import static java.util.stream.Collectors.toList;
 import static org.jboss.errai.common.client.dom.DOMUtil.*;
 
 @Dependent
@@ -46,21 +48,19 @@ public class CaseActionsListViewImpl extends AbstractView<CaseActionsPresenter>
 
     @Inject
     @DataField("simple-list")
-    Div simpleList;
+    private Div simpleList;
 
     @Inject
     @DataField("actions-list-header-image")
-    Span actionsListHeaderImage;
+    private Span actionsListHeaderImage;
 
     @Inject
     @DataField("actions-list-header-text")
-    Span actionsListHeaderText;
+    private Span actionsListHeaderText;
 
     @Inject
     @DataField("actions-list-header-counter")
-    Span actionsListHeaderCounter;
-
-    List<CaseActionSummary> allActionsList;
+    private Span actionsListHeaderCounter;
 
     @Inject
     @DataField("empty-list-item")
@@ -90,7 +90,6 @@ public class CaseActionsListViewImpl extends AbstractView<CaseActionsPresenter>
     }
 
     public void setCaseActionList(final List<CaseActionSummary> caseActionList) {
-        allActionsList = caseActionList;
         pagination.init(caseActionList,
                         this,
                         PAGE_SIZE);
@@ -101,7 +100,7 @@ public class CaseActionsListViewImpl extends AbstractView<CaseActionsPresenter>
             addCSSClass(emptyContainer,
                         "hidden");
         }
-        actionsListHeaderCounter.setTextContent(String.valueOf(allActionsList.size()));
+        actionsListHeaderCounter.setTextContent(String.valueOf(caseActionList.size()));
     }
 
     @Override
@@ -121,10 +120,20 @@ public class CaseActionsListViewImpl extends AbstractView<CaseActionsPresenter>
     @Override
     public void setVisibleItems(List<CaseActionSummary> visibleItems) {
         this.caseActionList.setModel(visibleItems);
+        setActions(visibleItems);
         int tasksSize = visibleItems.size();
         if (tasksSize > 1) {
             tasks.getComponent(tasksSize - 1).setLastElementStyle();
         }
+    }
+
+    private void setActions(List<CaseActionSummary> visibleItems) {
+        List<CaseActionItemView> caseActionItemViews = visibleItems.stream()
+                                                                   .map(task -> tasks.getComponent(task))
+                                                                   .filter(Optional::isPresent)
+                                                                   .map(Optional::get)
+                                                                   .collect(toList());
+        caseActionItemViews.forEach(action -> presenter.setAction(action));
     }
 
     @Override

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsPresenter.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsPresenter.java
@@ -51,7 +51,7 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
     private final Map<String, ProcessDefinitionSummary> processDefinitionSummaryMap = new HashMap<>();
 
     @Inject
-    User identity;
+    private User identity;
 
     @Inject
     private NewActionView newActionView;
@@ -73,9 +73,9 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
         newActionView.setCaseStagesList(cis.getStages());
         processDefinitionSummaryMap.clear();
         caseService.call(
-                (List<ProcessDefinitionSummary> processDefinitionsSumaries) -> {
+                (List<ProcessDefinitionSummary> processDefinitionSummaries) -> {
                     final List<String> processDefinitionNames = new ArrayList<>();
-                    for (ProcessDefinitionSummary processDefinitionSummary : processDefinitionsSumaries) {
+                    for (ProcessDefinitionSummary processDefinitionSummary : processDefinitionSummaries) {
                         processDefinitionNames.add(processDefinitionSummary.getName());
                         processDefinitionSummaryMap.put(processDefinitionSummary.getName(),
                                                         processDefinitionSummary);
@@ -190,6 +190,28 @@ public class CaseActionsPresenter extends AbstractCaseInstancePresenter<CaseActi
                           containerId,
                           caseId,
                           identity.getIdentifier());
+    }
+
+    void setAction(final CaseActionItemView caseActionItem) {
+        final CaseActionSummary caseActionItemModel = caseActionItem.getValue();
+
+        switch (caseActionItemModel.getActionStatus()) {
+            case AVAILABLE: {
+                caseActionItem.prepareAction(caseActionItemModel);
+                break;
+            }
+            case IN_PROGRESS: {
+                caseActionItem.addCreationDate();
+                final String actionOwner = caseActionItemModel.getActualOwner();
+                if (!isNullOrEmpty(actionOwner)) {
+                    caseActionItem.addActionOwner(actionOwner);
+                }
+                break;
+            }
+            case COMPLETED: {
+                caseActionItem.addCreationDate();
+            }
+        }
     }
 
     public interface CaseActionsView extends UberElement<CaseActionsPresenter> {

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsViewImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/actions/CaseActionsViewImpl.java
@@ -32,25 +32,24 @@ import org.jbpm.workbench.cm.model.CaseActionSummary;
 @Templated
 public class CaseActionsViewImpl extends AbstractView<CaseActionsPresenter> implements CaseActionsPresenter.CaseActionsView {
 
-    public static final String AVAILABLE_ACTIONS = "AVAILABLE";
-    public static final String INPROGRESS_ACTIONS = "IN_PROGRESS";
-    public static final String COMPLETED_ACTIONS = "COMPLETED";
+    private static final String AVAILABLE_ACTIONS = "AVAILABLE";
+    private static final String IN_PROGRESS_ACTIONS = "IN_PROGRESS";
+    private static final String COMPLETED_ACTIONS = "COMPLETED";
 
     @Inject
     @DataField("available-actions")
-    CaseActionsListViewImpl availableActions;
+    private CaseActionsListViewImpl availableActions;
 
     @Inject
     @DataField("inprogress-actions")
-    CaseActionsListViewImpl inprogressActions;
+    private CaseActionsListViewImpl inProgressActions;
 
     @Inject
     @DataField("completed-actions")
-    CaseActionsListViewImpl completedActions;
+    private CaseActionsListViewImpl completedActions;
 
     @Inject
     @DataField("actions")
-
     private Div actionsContainer;
 
     @Inject
@@ -60,7 +59,7 @@ public class CaseActionsViewImpl extends AbstractView<CaseActionsPresenter> impl
     public void init(final CaseActionsPresenter presenter) {
         this.presenter = presenter;
         availableActions.init(presenter);
-        inprogressActions.init(presenter);
+        inProgressActions.init(presenter);
         completedActions.init(presenter);
     }
 
@@ -72,7 +71,7 @@ public class CaseActionsViewImpl extends AbstractView<CaseActionsPresenter> impl
     @Override
     public void removeAllTasks() {
         availableActions.removeAllTasks();
-        inprogressActions.removeAllTasks();
+        inProgressActions.removeAllTasks();
         completedActions.removeAllTasks();
     }
 
@@ -83,7 +82,7 @@ public class CaseActionsViewImpl extends AbstractView<CaseActionsPresenter> impl
 
     @Override
     public void setInProgressActionsList(List<CaseActionSummary> caseActionList) {
-        inprogressActions.setCaseActionList(caseActionList);
+        inProgressActions.setCaseActionList(caseActionList);
     }
 
     @Override
@@ -98,7 +97,7 @@ public class CaseActionsViewImpl extends AbstractView<CaseActionsPresenter> impl
                                              "fa-flag-o",
                                              "kie-card__subtitle-icon",
                                              "kie-card__subtitle-icon--available");
-        inprogressActions.updateActionsHeader(translationService.format(INPROGRESS_ACTIONS),
+        inProgressActions.updateActionsHeader(translationService.format(IN_PROGRESS_ACTIONS),
                                               "fa",
                                               "fa-flag-checkered",
                                               "kie-card__subtitle-icon",

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/stages/CaseStagesPresenterTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/stages/CaseStagesPresenterTest.java
@@ -18,13 +18,11 @@ package org.jbpm.workbench.cm.client.stages;
 
 import org.jbpm.workbench.cm.client.util.AbstractCaseInstancePresenterTest;
 import org.jbpm.workbench.cm.model.CaseInstanceSummary;
-import org.jbpm.workbench.cm.model.CaseStageSummary;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -51,7 +49,7 @@ public class CaseStagesPresenterTest extends AbstractCaseInstancePresenterTest {
 
     @Before
     public void setup() {
-        caseStageItemViewMock = Mockito.mock(CaseStageItemViewImpl.class);
+        caseStageItemViewMock = mock(CaseStageItemViewImpl.class);
     }
 
     @Test
@@ -86,13 +84,5 @@ public class CaseStagesPresenterTest extends AbstractCaseInstancePresenterTest {
 
         verify(caseStageItemViewMock,
                never()).showStageActive();
-    }
-
-    private CaseStageSummary createCaseStageSummary(final String stageStatus) {
-        return CaseStageSummary.builder()
-                               .identifier("stage")
-                               .name("stageName")
-                               .status(stageStatus)
-                               .build();
     }
 }

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/util/AbstractCaseInstancePresenterTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/util/AbstractCaseInstancePresenterTest.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import org.jboss.errai.common.client.api.Caller;
 import org.jboss.errai.ui.client.local.spi.TranslationService;
 import org.jbpm.workbench.cm.model.CaseInstanceSummary;
+import org.jbpm.workbench.cm.model.CaseStageSummary;
 import org.jbpm.workbench.cm.service.CaseManagementService;
 import org.jbpm.workbench.cm.util.CaseStatus;
 import org.junit.Before;
@@ -63,6 +64,14 @@ public abstract class AbstractCaseInstancePresenterTest {
                 .caseDefinitionId(caseDefId)
                 .roleAssignments(Collections.emptyList())
                 .build();
+    }
+
+    protected CaseStageSummary createCaseStageSummary(final String stageStatus) {
+        return CaseStageSummary.builder()
+                               .identifier("stage")
+                               .name("stageName")
+                               .status(stageStatus)
+                               .build();
     }
 
     @Before


### PR DESCRIPTION
@cristianonicolai @nmirasch Added more tests around actions lists. It required a small re-factoring here and there and while at it, I aligned field access specifiers where seemed appropriate.

Please note the change in _CaseActionSummary_ ```equals``` implementation. The re-factoring I did to move some of the business logic to _CaseActionsPresenter_ reveled the problem with previous ```equals``` implementation. The ```id``` field can't be used to compare dynamic actions while being listed, as they don't have the concept of ```Id```. 