### PR TITLE
[7.7.x] RHPAM-687 - Immutable KIE servers cannot be directly monitored (#1051)

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerIntegration.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerIntegration.java
@@ -114,8 +114,16 @@ public class KieServerIntegration {
 
     public KieServicesClient getServerClient(String serverTemplateId,
                                              String containerId) {
-        return serverTemplatesClients.getOrDefault(serverTemplateId,
-                                                   emptyMap()).get(containerId);
+        KieServicesClient client = serverTemplatesClients.getOrDefault(serverTemplateId,
+                                                                       emptyMap()).get(containerId);
+
+         if (client == null) {
+             logger.warn("Container {} not found in server template {}, returning global kie server client",
+                          containerId,
+                          serverTemplateId);
+             client = getServerClient(serverTemplateId);
+         }
+         return client;
     }
 
     public KieServicesClient getAdminServerClient(String serverTemplateId,

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerIntegrationClientsTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerIntegrationClientsTest.java
@@ -93,6 +93,9 @@ public class KieServerIntegrationClientsTest {
                      kieServerIntegration.getServerTemplatesClients().get(serverTemplateId).size());
         assertNotNull(kieServerIntegration.getServerTemplatesClients().get(serverTemplateId).get(SERVER_TEMPLATE_KEY));
         assertNotNull(kieServerIntegration.getServerTemplatesClients().get(serverTemplateId).get(containerSpec.getId()));
+        assertNotNull(kieServerIntegration.getServerClient(serverTemplateId, "not-existing"));
+        assertEquals(kieServerIntegration.getServerTemplatesClients().get(serverTemplateId).get(SERVER_TEMPLATE_KEY),
+                     kieServerIntegration.getServerClient(serverTemplateId, "not-existing"));
         assertEquals(1,
                      kieServerIntegration.getServerInstancesById().size());
         assertNotNull(kieServerIntegration.getServerInstancesById().get(serverInstanceId2));


### PR DESCRIPTION
depends on https://github.com/kiegroup/droolsjbpm-integration/pull/1432