### PR TITLE
JBPM-7213: Tasks First Due Date update writes null to task log

### DIFF
--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/tasklogs/TaskLogsViewImpl.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/tasklogs/TaskLogsViewImpl.java
@@ -53,7 +53,7 @@ public class TaskLogsViewImpl extends Composite implements TaskLogsPresenter.Tas
         removeAllChildren(logTextArea);
         logs.forEach(log -> {
             HTMLElement li = getDocument().createElement("li");
-            li.setTextContent(SafeHtmlUtils.htmlEscape(log));
+            li.setInnerHTML(SafeHtmlUtils.htmlEscape(log));
             logTextArea.appendChild(li);
         });
     }


### PR DESCRIPTION
The logs can Introduce characters like ' that are replaced at  SafeHtmlUtils.htmlEscape. To be displayed we need setInnerHTML instead  setTextContent