### PR TITLE
JBPM-7313: Case List: Should have refresh option

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/list/CaseInstanceListSearchViewImpl.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/list/CaseInstanceListSearchViewImpl.java
@@ -166,6 +166,11 @@ public class CaseInstanceListSearchViewImpl extends AbstractView<CaseInstanceLis
                      true);
     }
 
+    @EventHandler("refresh-case-list")
+    public void onRefreshCaseClick(final @ForEvent("click") MouseEvent event) {
+        presenter.refreshData();
+    }
+
     private void onSortChange(final HTMLElement toHide,
                               final HTMLElement toShow,
                               final Boolean sortByAsc) {

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/list/CaseInstanceListViewImpl.html
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/java/org/jbpm/workbench/cm/client/list/CaseInstanceListViewImpl.html
@@ -28,9 +28,14 @@
                             <span class="fa fa-sort-numeric-desc"></span>
                         </button>
                     </div>
-                    <div class="form-group">
-                        <button class="btn btn-primary" type="button" data-field="start-case" data-i18n-key="StartCase"></button>
+
+                    <div class="form-group pull-right">
+                            <button class="btn btn-link" type="button" data-field="refresh-case-list" title="refresh-case-list-title">
+                                <i class="fa fa-refresh"></i>
+                            </button>
+                            <button class="btn btn-primary" type="button" data-field="start-case" data-i18n-key="StartCase"></button>
                     </div>
+
                 </form>
             </div>
         </div>

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/resources/org/jbpm/workbench/cm/client/resources/i18n/Constants.properties
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/main/resources/org/jbpm/workbench/cm/client/resources/i18n/Constants.properties
@@ -112,3 +112,4 @@ More=...more
 SubProcess=Sub Process
 HumanTask=Human Task
 Milestone=Milestone
+refresh-case-list-title=Refresh

--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/list/CaseInstanceListSearchViewTest.java
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-client/src/test/java/org/jbpm/workbench/cm/client/list/CaseInstanceListSearchViewTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.cm.client.list;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CaseInstanceListSearchViewTest {
+
+    @InjectMocks
+    CaseInstanceListSearchViewImpl actions;
+
+    @Mock
+    CaseInstanceListPresenter presenter;
+
+    @Test
+    public void testRefreshCaseList(){
+        actions.onRefreshCaseClick(null);
+
+        verify(presenter).refreshData();
+    }
+
+    @Test
+    public void testCreateCaseClick(){
+        actions.onCreateCaseClick(null);
+
+        verify(presenter).createCaseInstance();
+    }
+
+}


### PR DESCRIPTION
@cristianonicolai  I think the PR is not ready.
I just want to make sure my PR on right way.
Actually, I have two way for the issue.
first, it is the PR.
if we choice it, I think we need choice it's style , it is like start case button, or I will try to copy  RefreshMenuBuilder's style.
another, We can copy [code](https://github.com/Cory-jbpm/jbpm-wb/blob/0a4ffbd3045d0bd22d6f03dcbd4d46a0aaf60671/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/list/ProcessInstanceListPresenter.java#L387)  .
But I find , jbpm-case-mgmt don't have many gwt modeles, I can not inherit all modeles.
In the same time, I find case list page different to process instance list page.

I think, the PR miss unit test, can you give me example for it.
Please review it.
Thanks