### PR TITLE
[7.7.x] RHPAM-1132 - JBPM failed to start because of timeout issue while regi…

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
@@ -8,7 +8,7 @@
   {
     "query-name": "jbpmProcessInstancesWithVariables",
     "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select vil.processInstanceId, vil.processId, vil.id, vil.variableId, vil.value from VariableInstanceLog vil where vil.id = (select MAX(v.id) from VariableInstanceLog v where v.variableId = vil.variableId and v.processInstanceId = vil.processInstanceId)",
+    "query-expression": "select vil.processInstanceId, vil.processId, vil.id, vil.variableId, vil.value from VariableInstanceLog vil where vil.id in (select MAX(v.id) from VariableInstanceLog v group by v.variableId, v.processInstanceId)",
     "query-target": "CUSTOM"
   },
   {


### PR DESCRIPTION
…stering jbpmProcessInstancesWithVariables data-set due to huge data in variableinstancelog table (#1132)