### PR TITLE
JBPM-7319: Processes & Task Dashboard don't show data from undeployed…

### DIFF
--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/pom.xml
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/pom.xml
@@ -74,6 +74,10 @@
       <artifactId>kie-server-controller-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.kie.server</groupId>
+      <artifactId>kie-server-api</artifactId>
+    </dependency>
     <!-- Dashbuilder -->
 
     <dependency>

--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/AbstractDashboard.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/AbstractDashboard.java
@@ -17,6 +17,7 @@
 package org.jbpm.dashboard.renderer.client.panel;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.event.Event;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
 
@@ -31,6 +32,7 @@ import org.dashbuilder.displayer.client.DisplayerCoordinator;
 import org.dashbuilder.displayer.client.DisplayerLocator;
 import org.dashbuilder.renderer.client.metric.MetricDisplayer;
 import org.dashbuilder.renderer.client.table.TableDisplayer;
+import org.jboss.errai.common.client.api.Caller;
 import org.jbpm.workbench.common.client.PerspectiveIds;
 import org.jbpm.workbench.common.client.menu.PrimaryActionMenuBuilder;
 import org.jbpm.workbench.ks.integration.ConsoleDataSetLookup;
@@ -38,12 +40,14 @@ import org.jbpm.workbench.common.client.menu.ServerTemplateSelectorMenuBuilder;
 import org.jbpm.dashboard.renderer.client.panel.formatter.DurationFormatter;
 import org.jbpm.dashboard.renderer.client.panel.i18n.DashboardI18n;
 import org.jbpm.dashboard.renderer.client.panel.widgets.ProcessBreadCrumb;
+import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
 import org.uberfire.client.mvp.PerspectiveManager;
 import org.uberfire.client.mvp.PlaceManager;
 import org.uberfire.client.workbench.events.ClosePlaceEvent;
 import org.uberfire.ext.widgets.common.client.breadcrumbs.UberfireBreadcrumbs;
 import org.uberfire.mvp.Command;
 import org.uberfire.mvp.Commands;
+import org.uberfire.workbench.events.NotificationEvent;
 import org.uberfire.workbench.model.menu.MenuFactory;
 import org.uberfire.workbench.model.menu.Menus;
 
@@ -64,13 +68,31 @@ public abstract class AbstractDashboard {
     protected ServerTemplateSelectorMenuBuilder serverTemplateSelectorMenuBuilder;
 
     UberfireBreadcrumbs breadcrumbs;
+    protected Caller<SpecManagementService> specManagementService;
+
+    protected Event<NotificationEvent> notificationEvent;
+
 
     private PerspectiveManager perspectiveManager;
 
     private String detailScreenId;
 
+    @Inject
+    public void setSpecManagementService(final Caller<SpecManagementService> specManagementService) {
+        this.specManagementService = specManagementService;
+    }
+
+    @Inject
+    public void setNotificationEvent(final Event<NotificationEvent> notificationEvent) {
+        this.notificationEvent = notificationEvent;
+    }
+
     public String getPerspectiveId() {
         return perspectiveManager.getCurrentPerspective().getIdentifier();
+    }
+
+    protected void displayNotification(String message) {
+        notificationEvent.fire(new NotificationEvent(message));
     }
 
     public AbstractDashboard() {

--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/i18n/DashboardI18n.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/renderer/client/panel/i18n/DashboardI18n.java
@@ -79,6 +79,8 @@ public interface DashboardI18n {
 
     String processStatusSuspended();
 
+    String processDetailsNotAvailableContainerNotStarted(String containerId);
+
     String totalProcesses();
 
     String pendingProcesses();
@@ -234,6 +236,8 @@ public interface DashboardI18n {
     String taskTableDuration();
 
     String taskDetailsNotAvailable();
+
+    String taskDetailsNotAvailableContainerNotStarted(String containerId);
 
     String displayerNotFound(String name);
 

--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/resources/org/jbpm/dashboard/renderer/client/panel/i18n/DashboardConstants.properties
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/resources/org/jbpm/dashboard/renderer/client/panel/i18n/DashboardConstants.properties
@@ -65,6 +65,7 @@ processCount=Process count
 processUser=User
 processStartDate=Start date
 processEndDate=End date
+processDetailsNotAvailableContainerNotStarted=Process details not available, deployment container {0} is not started
 
 totalTasks=Total Tasks
 tasksCreated=Tasks Created
@@ -117,6 +118,7 @@ taskTableEndDate=End
 taskTableDuration=Duration
 
 taskDetailsNotAvailable=Task details not available
+taskDetailsNotAvailableContainerNotStarted=Task details not available, deployment container {0} is not started
 
 displayerNotFound=Displayer not found\: {0}
 

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/taskdetailsmulti/TaskDetailsMultiViewImpl.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/editors/taskdetailsmulti/TaskDetailsMultiViewImpl.java
@@ -16,6 +16,8 @@
 package org.jbpm.workbench.ht.client.editors.taskdetailsmulti;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -29,6 +31,7 @@ import org.gwtbootstrap3.client.ui.TabContent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TabPane;
 import org.jbpm.workbench.ht.client.resources.i18n.Constants;
+import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
 public class TaskDetailsMultiViewImpl extends Composite
@@ -69,6 +72,9 @@ public class TaskDetailsMultiViewImpl extends Composite
     private TabPane taskLogsPane;
 
     private TabListItem taskLogsTab;
+
+    @Inject
+    private Event<NotificationEvent> notification;
 
     @Override
     public void init(final TaskDetailsMultiPresenter presenter) {
@@ -221,6 +227,11 @@ public class TaskDetailsMultiViewImpl extends Composite
 
         taskLogsPane.setVisible(true);
         taskLogsTab.setVisible(true);
+    }
+
+    @Override
+    public void displayNotification(String text) {
+        notification.fire(new NotificationEvent(text));
     }
 
     interface Binder

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/resources/i18n/Constants.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/java/org/jbpm/workbench/ht/client/resources/i18n/Constants.java
@@ -248,4 +248,6 @@ public interface Constants extends Messages {
     String TaskListCouldNotBeLoaded();
     
     String Errors();
+
+    String TaskDetailsNotAvailableContainerNotStarted(String containerId);
 }

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/resources/org/jbpm/workbench/ht/client/resources/i18n/Constants.properties
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/main/resources/org/jbpm/workbench/ht/client/resources/i18n/Constants.properties
@@ -117,3 +117,5 @@ Failed=Failed
 Error=Error
 Exited=Exited
 Obsolete=Obsolete
+TaskDetailsNotAvailableContainerNotStarted=Task details not available, deployment container {0} is not started
+

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/test/java/org/jbpm/workbench/ht/client/editors/taskdetailsmulti/TaskDetailsMultiPresenterTest.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-client/src/test/java/org/jbpm/workbench/ht/client/editors/taskdetailsmulti/TaskDetailsMultiPresenterTest.java
@@ -30,6 +30,10 @@ import org.jbpm.workbench.ht.service.TaskService;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.controller.api.model.spec.ContainerSpec;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -79,6 +83,17 @@ public class TaskDetailsMultiPresenterTest {
     @SuppressWarnings("unused")
     private TaskDetailsPresenter taskDetailsPresenter;
 
+    @Mock
+    ContainerSpec containerSpecMock;
+
+    @Mock
+    ServerTemplate serverTemplateMock;
+
+    @Mock
+    SpecManagementService specManagementService;
+
+    Caller<SpecManagementService> specManagementServiceCaller;
+
     @InjectMocks
     private TaskDetailsMultiPresenter presenter;
 
@@ -94,6 +109,12 @@ public class TaskDetailsMultiPresenterTest {
         when(taskFormViewMock.getDisplayerView()).thenReturn(formDisplayerViewMock);
         doNothing().when(changeTitleWidgetEvent).fire(any(ChangeTitleWidgetEvent.class));
         doNothing().when(taskSelectionEvent).fire(any(TaskSelectionEvent.class));
+
+        specManagementServiceCaller = new CallerMock<>(specManagementService);
+        presenter.setSpecManagementService(specManagementServiceCaller);
+        when(specManagementService.getServerTemplate(anyString())).thenReturn(serverTemplateMock);
+        when(serverTemplateMock.getContainerSpec(anyString())).thenReturn(containerSpecMock);
+        when(containerSpecMock.getStatus()).thenReturn(KieContainerStatus.STARTED);
     }
 
     @Test
@@ -218,5 +239,49 @@ public class TaskDetailsMultiPresenterTest {
         verify(view,
                times(2)).displayAllTabs();
         verify(view).resetTabs(false);
+    }
+
+    @Test
+    public void refreshWithContainerStoppedTest() {
+        when(containerSpecMock.getStatus()).thenReturn(KieContainerStatus.STOPPED);
+        Long taskId = 1L;
+        String containerId = "container1.2";
+        String serverTemplateId = "serverTemplateId";
+        TaskSummary taskSummary =
+                TaskSummary.builder()
+                        .deploymentId(containerId)
+                        .id(taskId)
+                        .name("name")
+                        .description("description")
+                        .expirationTime(new Date())
+                        .status("Completed")
+                        .actualOwner("Rob")
+                        .priority(5)
+                        .processInstanceId(2L)
+                        .processId("Evaluation")
+                        .build();
+
+        when(taskServiceMock.getTask(serverTemplateId,
+                                     containerId,
+                                     taskId)).thenReturn(taskSummary);
+        presenter.onTaskSelectionEvent(new TaskSelectionEvent(serverTemplateId,
+                                                              taskSummary.getDeploymentId(),
+                                                              taskSummary.getId(),
+                                                              taskSummary.getName(),
+                                                              false,
+                                                              false,
+                                                              taskSummary.getDescription(),
+                                                              taskSummary.getExpirationTime(),
+                                                              taskSummary.getStatus(),
+                                                              taskSummary.getActualOwner(),
+                                                              taskSummary.getPriority(),
+                                                              taskSummary.getProcessInstanceId(),
+                                                              taskSummary.getProcessId()));
+        verify(view).displayAllTabs();
+        verify(view).resetTabs(false);
+
+        presenter.onRefresh();
+        verify(view).displayNotification(anyString());
+        verifyNoMoreInteractions(taskSelectionEvent);
     }
 }

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
@@ -15,13 +15,13 @@
     "query-name": "processesMonitoring",
     "query-source": "${org.kie.server.persistence.ds}",
     "query-expression": "select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, log.duration, log.user_identity, log.processVersion, log.processName, log.externalId from ProcessInstanceLog log",
-    "query-target": "FILTERED_PROCESS"
+    "query-target": "CUSTOM"
   },
   {
     "query-name": "tasksMonitoring",
     "query-source": "${org.kie.server.persistence.ds}",
     "query-expression": "select p.processName, p.externalId, t.taskId, t.taskName, t.status, t.createdDate, t.startDate, t.endDate, t.processInstanceId, t.userId, t.duration from ProcessInstanceLog p inner join BAMTaskSummary t on (t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk from BAMTaskSummary group by taskId) d on t.pk = d.pk",
-    "query-target": "FILTERED_PROCESS"
+    "query-target": "CUSTOM"
   },
   {
     "query-name": "jbpmRequestList",

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/definition/list/ProcessDefinitionListPresenter.java
@@ -43,6 +43,9 @@ import org.jbpm.workbench.pr.events.ProcessInstanceSelectionEvent;
 import org.jbpm.workbench.pr.model.ProcessDefinitionKey;
 import org.jbpm.workbench.pr.model.ProcessSummary;
 import org.jbpm.workbench.pr.service.ProcessRuntimeDataService;
+import org.kie.server.api.model.KieContainerStatus;
+import org.kie.server.controller.api.model.spec.ServerTemplate;
+import org.kie.workbench.common.screens.server.management.service.SpecManagementService;
 import org.uberfire.client.annotations.WorkbenchMenu;
 import org.uberfire.client.annotations.WorkbenchPartView;
 import org.uberfire.client.annotations.WorkbenchScreen;
@@ -74,6 +77,8 @@ public class ProcessDefinitionListPresenter extends AbstractScreenListPresenter<
 
     @Inject
     private Caller<ProcessRuntimeDataService> processRuntimeDataService;
+
+    protected Caller<SpecManagementService> specManagementService;
 
     protected AuthorizationManager authorizationManager;
 
@@ -217,17 +222,26 @@ public class ProcessDefinitionListPresenter extends AbstractScreenListPresenter<
     }
 
     public void refreshNewProcessInstance(@Observes NewProcessInstanceEvent newProcessInstance) {
-        setupDetailBreadcrumb(placeManager,
-                              commonConstants.Manage_Process_Definitions(),
-                              constants.ProcessInstanceBreadcrumb(newProcessInstance.getNewProcessInstanceId()),
-                              PerspectiveIds.PROCESS_INSTANCE_DETAILS_SCREEN);
-        placeManager.goTo(PerspectiveIds.PROCESS_INSTANCE_DETAILS_SCREEN);
-        processInstanceSelected.fire(new ProcessInstanceSelectionEvent(newProcessInstance.getDeploymentId(),
-                                                                       newProcessInstance.getNewProcessInstanceId(),
-                                                                       newProcessInstance.getNewProcessDefId(),
-                                                                       newProcessInstance.getProcessDefName(),
-                                                                       newProcessInstance.getNewProcessInstanceStatus(),
-                                                                       newProcessInstance.getServerTemplateId()));
+        specManagementService.call((ServerTemplate serverTemplate) -> {
+            if (serverTemplate != null &&
+                    serverTemplate.getContainerSpec(newProcessInstance.getDeploymentId()) != null &&
+                    serverTemplate.getContainerSpec(newProcessInstance.getDeploymentId()).getStatus().equals(KieContainerStatus.STARTED)) {
+
+                setupDetailBreadcrumb(placeManager,
+                                      commonConstants.Manage_Process_Definitions(),
+                                      constants.ProcessInstanceBreadcrumb(newProcessInstance.getNewProcessInstanceId()),
+                                      PerspectiveIds.PROCESS_INSTANCE_DETAILS_SCREEN);
+                placeManager.goTo(PerspectiveIds.PROCESS_INSTANCE_DETAILS_SCREEN);
+                processInstanceSelected.fire(new ProcessInstanceSelectionEvent(newProcessInstance.getDeploymentId(),
+                                                                               newProcessInstance.getNewProcessInstanceId(),
+                                                                               newProcessInstance.getNewProcessDefId(),
+                                                                               newProcessInstance.getProcessDefName(),
+                                                                               newProcessInstance.getNewProcessInstanceStatus(),
+                                                                               newProcessInstance.getServerTemplateId()));
+            } else {
+                view.displayNotification(constants.ProcessDetailsNotAvailableContainerNotStarted(newProcessInstance.getDeploymentId()));
+            }
+        }).getServerTemplate(newProcessInstance.getServerTemplateId());
     }
 
     public Predicate<ProcessSummary> getViewProcessInstanceActionCondition() {
@@ -255,6 +269,11 @@ public class ProcessDefinitionListPresenter extends AbstractScreenListPresenter<
     @Inject
     public void setProcessRuntimeDataService(final Caller<ProcessRuntimeDataService> processRuntimeDataService) {
         this.processRuntimeDataService = processRuntimeDataService;
+    }
+
+    @Inject
+    public void setSpecManagementService(final Caller<SpecManagementService> specManagementService) {
+        this.specManagementService = specManagementService;
     }
 
     public interface ProcessDefinitionListView extends ListView<ProcessSummary, ProcessDefinitionListPresenter> {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenter.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import com.google.gwt.safehtml.shared.SafeHtmlBuilder;
 import com.google.gwt.user.client.ui.IsWidget;
 import org.jboss.errai.common.client.api.Caller;
-import org.jboss.errai.common.client.api.RemoteCallback;
 import org.jbpm.workbench.pr.model.NodeInstanceSummary;
 import org.jbpm.workbench.pr.model.ProcessInstanceKey;
 import org.jbpm.workbench.pr.model.ProcessInstanceSummary;
@@ -84,72 +83,68 @@ public class ProcessInstanceDetailsTabPresenter {
         view.setStateText("");
         view.setCurrentActivitiesListBox("");
 
-        processRuntimeDataService.call(new RemoteCallback<ProcessInstanceSummary>() {
-            @Override
-            public void callback(final ProcessInstanceSummary process) {
-                view.setProcessDefinitionIdText(process.getProcessId());
-                view.setProcessVersionText(process.getProcessVersion());
-                view.setProcessDeploymentText(process.getDeploymentId());
-                view.setCorrelationKeyText(process.getCorrelationKey());
-                if (process.getParentId() > 0) {
-                    view.setParentProcessInstanceIdText(process.getParentId().toString());
-                } else {
-                    view.setParentProcessInstanceIdText(constants.No_Parent_Process_Instance());
-                }
-
-                String statusStr = constants.Unknown();
-                switch (process.getState()) {
-                    case ProcessInstance.STATE_ACTIVE:
-                        statusStr = constants.Active();
-                        break;
-                    case ProcessInstance.STATE_ABORTED:
-                        statusStr = constants.Aborted();
-                        break;
-                    case ProcessInstance.STATE_COMPLETED:
-                        statusStr = constants.Completed();
-                        break;
-                    case ProcessInstance.STATE_PENDING:
-                        statusStr = constants.Pending();
-                        break;
-                    case ProcessInstance.STATE_SUSPENDED:
-                        statusStr = constants.Suspended();
-                        break;
-                    default:
-                        break;
-                }
-                view.setStateText(statusStr);
-                
-                String slaComplianceStr = mapSlaCompliance(process);
-                view.setSlaComplianceText(slaComplianceStr);
-
-                if (process.getActiveTasks() != null && !process.getActiveTasks().isEmpty()) {
-                    SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-
-                    for (UserTaskSummary uts : process.getActiveTasks()) {
-                        safeHtmlBuilder.appendEscapedLines(uts.getName() + " (" + uts.getStatus() + ")  " + constants.Owner() + ": " + uts.getOwner() + " \n");
+        processRuntimeDataService.call(
+                (final ProcessInstanceSummary process) -> {
+                    view.setProcessDefinitionIdText(process.getProcessId());
+                    view.setProcessVersionText(process.getProcessVersion());
+                    view.setProcessDeploymentText(process.getDeploymentId());
+                    view.setCorrelationKeyText(process.getCorrelationKey());
+                    if (process.getParentId() > 0) {
+                        view.setParentProcessInstanceIdText(process.getParentId().toString());
+                    } else {
+                        view.setParentProcessInstanceIdText(constants.No_Parent_Process_Instance());
                     }
-                    view.setActiveTasksListBox(safeHtmlBuilder.toSafeHtml().asString());
-                }
-                
-            }
-        }).getProcessInstance(serverTemplateId,
-                              new ProcessInstanceKey(serverTemplateId,
-                                                     deploymentId,
-                                                     Long.parseLong(processId)));
 
-        processRuntimeDataService.call(new RemoteCallback<List<NodeInstanceSummary>>() {
-            @Override
-            public void callback(final List<NodeInstanceSummary> details) {
-                final SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
-                for (NodeInstanceSummary nis : details) {
-                    safeHtmlBuilder.appendEscapedLines(nis.getTimestamp() + ": "
-                                                               + nis.getId() + " - " + nis.getNodeName() + " (" + nis.getType() + ") \n");
+                    String statusStr = constants.Unknown();
+                    switch (process.getState()) {
+                        case ProcessInstance.STATE_ACTIVE:
+                            statusStr = constants.Active();
+                            break;
+                        case ProcessInstance.STATE_ABORTED:
+                            statusStr = constants.Aborted();
+                            break;
+                        case ProcessInstance.STATE_COMPLETED:
+                            statusStr = constants.Completed();
+                            break;
+                        case ProcessInstance.STATE_PENDING:
+                            statusStr = constants.Pending();
+                            break;
+                        case ProcessInstance.STATE_SUSPENDED:
+                            statusStr = constants.Suspended();
+                            break;
+                        default:
+                            break;
+                    }
+                    view.setStateText(statusStr);
+
+                    String slaComplianceStr = mapSlaCompliance(process);
+                    view.setSlaComplianceText(slaComplianceStr);
+
+                    if (process.getActiveTasks() != null && !process.getActiveTasks().isEmpty()) {
+                        SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+
+                        for (UserTaskSummary uts : process.getActiveTasks()) {
+                            safeHtmlBuilder.appendEscapedLines(uts.getName() + " (" + uts.getStatus() + ")  " + constants.Owner() + ": " + uts.getOwner() + " \n");
+                        }
+                        view.setActiveTasksListBox(safeHtmlBuilder.toSafeHtml().asString());
+                    }
+                }).getProcessInstance(serverTemplateId,
+                                      new ProcessInstanceKey(serverTemplateId,
+                                                             deploymentId,
+                                                             Long.parseLong(processId)));
+
+        processRuntimeDataService.call(
+                (final List<NodeInstanceSummary> details) -> {
+                    final SafeHtmlBuilder safeHtmlBuilder = new SafeHtmlBuilder();
+                    for (NodeInstanceSummary nis : details) {
+                        safeHtmlBuilder.appendEscapedLines(nis.getTimestamp() + ": "
+                                                                   + nis.getId() + " - " + nis.getNodeName() + " (" + nis.getType() + ") \n");
+                    }
+                    view.setCurrentActivitiesListBox(safeHtmlBuilder.toSafeHtml().asString());
                 }
-                view.setCurrentActivitiesListBox(safeHtmlBuilder.toSafeHtml().asString());
-            }
-        }).getProcessInstanceActiveNodes(serverTemplateId,
-                                         deploymentId,
-                                         Long.parseLong(processId));
+        ).getProcessInstanceActiveNodes(serverTemplateId,
+                                        deploymentId,
+                                        Long.parseLong(processId));
     }
 
     protected String mapSlaCompliance(ProcessInstanceSummary process) {
@@ -193,7 +188,7 @@ public class ProcessInstanceDetailsTabPresenter {
         void setCorrelationKeyText(String value);
 
         void setParentProcessInstanceIdText(String value);
-        
+
         void setSlaComplianceText(String value);
     }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsViewImpl.java
@@ -16,6 +16,8 @@
 package org.jbpm.workbench.pr.client.editors.instance.details;
 
 import javax.enterprise.context.Dependent;
+import javax.enterprise.event.Event;
+import javax.inject.Inject;
 
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.uibinder.client.UiBinder;
@@ -29,6 +31,7 @@ import org.gwtbootstrap3.client.ui.TabContent;
 import org.gwtbootstrap3.client.ui.TabListItem;
 import org.gwtbootstrap3.client.ui.TabPane;
 import org.jbpm.workbench.pr.client.resources.i18n.Constants;
+import org.uberfire.workbench.events.NotificationEvent;
 
 @Dependent
 public class ProcessInstanceDetailsViewImpl extends Composite implements ProcessInstanceDetailsPresenter.ProcessInstanceDetailsView {
@@ -64,6 +67,9 @@ public class ProcessInstanceDetailsViewImpl extends Composite implements Process
     private TabPane diagramPane;
 
     private ProcessInstanceDetailsPresenter presenter;
+
+    @Inject
+    private Event<NotificationEvent> notification;
 
     @Override
     public void init(final ProcessInstanceDetailsPresenter presenter) {
@@ -173,6 +179,11 @@ public class ProcessInstanceDetailsViewImpl extends Composite implements Process
 
         diagramPane.setVisible(true);
         diagramTab.setVisible(true);
+    }
+
+    @Override
+    public void displayNotification(String text) {
+        notification.fire(new NotificationEvent(text));
     }
 
     interface Binder extends UiBinder<Widget, ProcessInstanceDetailsViewImpl> {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/resources/i18n/Constants.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/resources/i18n/Constants.java
@@ -284,4 +284,6 @@ public interface Constants extends Messages {
     String SlaDueDate();
 
     String Process_Diagram_Not_Found();
+
+    String ProcessDetailsNotAvailableContainerNotStarted(String containerId);
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/resources/org/jbpm/workbench/pr/client/resources/i18n/Constants.properties
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/resources/org/jbpm/workbench/pr/client/resources/i18n/Constants.properties
@@ -127,3 +127,4 @@ SlaViolated=Violated
 SlaCompliance=SLA Compliance
 SlaDueDate=SLA Due Date
 Process_Diagram_Not_Found=Process diagram not found
+ProcessDetailsNotAvailableContainerNotStarted=Process details not available, deployment container {0} is not started


### PR DESCRIPTION
… Kie containers
Introduce the SpecManagementService to check the container status before accessing the process instance and task details.
Removed the dashboard  preprocessor to show all server template items and not filter by containerId
