### PR TITLE
Add profile to enable skipping of gwt compilation of showcases

### DIFF
--- a/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/pom.xml
+++ b/jbpm-wb-case-mgmt/jbpm-wb-case-mgmt-showcase/pom.xml
@@ -714,6 +714,21 @@
         </pluginManagement>
       </build>
     </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>

--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1923,6 +1923,21 @@
         </plugins>
       </build>
     </profile>
+    <!-- profile to disable GWT compilation of showcase (useful in full downstream builds) -->
+    <profile>
+      <id>no-showcase</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>gwt-maven-plugin</artifactId>
+            <configuration>
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
 </project>


### PR DESCRIPTION
Hello @cristianonicolai  and @nmirasch ,

I'm introducing a new profile that will enable to skip gwt compilation of showcases in `downstream-pullrequests` jobs. In normal build, nothing is skipped. Only when you add `-Pno-showcase` to mvn command line, the showcases won't be gwt-compiled. Please let me know if you're ok with this change / if you can think of better way to achieve the skipping.