### PR TITLE
[master] AF-1226: Improve error handling displaying additional info to the GenericErrorPopup

### DIFF
--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/dataset/AbstractDataSetReadyCallback.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/dataset/AbstractDataSetReadyCallback.java
@@ -63,8 +63,7 @@ public abstract class AbstractDataSetReadyCallback implements DataSetReadyCallba
     @Override
     public boolean onError(final ClientRuntimeError error) {
         view.hideBusyIndicator();
-        errorCallback.error(null,
-                            error.getThrowable());
+        errorCallback.error(error.getThrowable());
         GWT.log("DataSet with UUID [ " + UUID + " ] error: ",
                 error.getThrowable());
         return false;

--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/dataset/DataSetAwareSelect.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/dataset/DataSetAwareSelect.java
@@ -118,8 +118,7 @@ public class DataSetAwareSelect {
                                                     }
                                                 });
         } catch (Exception ex) {
-            new DefaultWorkbenchErrorCallback().error(null,
-                                                      ex);
+            new DefaultWorkbenchErrorCallback().error(ex);
         }
     }
 

--- a/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/dataset/AbstractDataSetReadyCallbackTest.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/dataset/AbstractDataSetReadyCallbackTest.java
@@ -67,8 +67,7 @@ public class AbstractDataSetReadyCallbackTest {
         verify(view).hideBusyIndicator();
         verify(errorPopup).showMessage(anyString());
         verify(errorCallback,
-               never()).error(any(Message.class),
-                              any(Throwable.class));
+               never()).error(any(Throwable.class));
     }
 
     @Test
@@ -78,7 +77,6 @@ public class AbstractDataSetReadyCallbackTest {
         verify(view).hideBusyIndicator();
         verify(errorPopup,
                never()).showMessage(anyString());
-        verify(errorCallback).error(any(Message.class),
-                                    any(Throwable.class));
+        verify(errorCallback).error(any(Throwable.class));
     }
 }

--- a/jbpm-wb-integration/jbpm-wb-integration-client/src/main/java/org/jbpm/workbench/wi/client/editors/deployment/descriptor/items/ParametersModal.java
+++ b/jbpm-wb-integration/jbpm-wb-integration-client/src/main/java/org/jbpm/workbench/wi/client/editors/deployment/descriptor/items/ParametersModal.java
@@ -25,7 +25,7 @@ import org.jboss.errai.ioc.client.api.ManagedInstance;
 import org.jbpm.workbench.wi.dd.model.Parameter;
 import org.kie.workbench.common.widgets.client.widget.ListItemPresenter;
 import org.kie.workbench.common.widgets.client.widget.ListPresenter;
-import org.kie.workbench.common.screens.library.client.settings.util.modal.Elemental2Modal;
+import org.uberfire.ext.editor.commons.client.file.popups.elemental2.Elemental2Modal;
 
 @Dependent
 public class ParametersModal extends Elemental2Modal<ParametersModalView> {

--- a/jbpm-wb-integration/jbpm-wb-integration-client/src/main/java/org/jbpm/workbench/wi/client/editors/deployment/descriptor/items/ParametersModalView.java
+++ b/jbpm-wb-integration/jbpm-wb-integration-client/src/main/java/org/jbpm/workbench/wi/client/editors/deployment/descriptor/items/ParametersModalView.java
@@ -32,7 +32,7 @@ import org.jboss.errai.ui.shared.api.annotations.DataField;
 import org.jboss.errai.ui.shared.api.annotations.EventHandler;
 import org.jboss.errai.ui.shared.api.annotations.Templated;
 import org.kie.workbench.common.widgets.client.widget.ListItemView;
-import org.kie.workbench.common.screens.library.client.settings.util.modal.Elemental2Modal;
+import org.uberfire.ext.editor.commons.client.file.popups.elemental2.Elemental2Modal;
 
 @Templated
 public class ParametersModalView implements Elemental2Modal.View<ParametersModal> {

--- a/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/client/ShowcaseEntryPoint.java
+++ b/jbpm-wb-showcase/src/main/java/org/jbpm/workbench/client/ShowcaseEntryPoint.java
@@ -33,6 +33,7 @@ import org.jbpm.workbench.client.perspectives.ProcessAdminSettingsPerspective;
 import org.jbpm.workbench.client.perspectives.TaskAdminSettingsPerspective;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
 import org.kie.workbench.common.workbench.client.entrypoint.DefaultWorkbenchEntryPoint;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.uberfire.client.mvp.ActivityBeansCache;
 import org.uberfire.client.views.pfly.menu.MainBrand;
@@ -68,9 +69,11 @@ public class ShowcaseEntryPoint extends DefaultWorkbenchEntryPoint {
                               final User identity,
                               final DefaultAdminPageHelper adminPageHelper,
                               final DefaultWorkbenchFeaturesMenusHelper menusHelper,
-                              final WorkbenchMegaMenuPresenter menuBar) {
+                              final WorkbenchMegaMenuPresenter menuBar,
+                              final DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback) {
         super(appConfigService,
-              activityBeansCache);
+              activityBeansCache,
+              defaultWorkbenchErrorCallback);
         this.iocManager = iocManager;
         this.identity = identity;
         this.menusHelper = menusHelper;

--- a/jbpm-wb-showcase/src/test/java/org/jbpm/workbench/client/ShowcaseEntryPointTest.java
+++ b/jbpm-wb-showcase/src/test/java/org/jbpm/workbench/client/ShowcaseEntryPointTest.java
@@ -28,6 +28,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.workbench.client.admin.DefaultAdminPageHelper;
+import org.kie.workbench.common.workbench.client.error.DefaultWorkbenchErrorCallback;
 import org.kie.workbench.common.workbench.client.menu.DefaultWorkbenchFeaturesMenusHelper;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -68,6 +69,9 @@ public class ShowcaseEntryPointTest {
     @Mock
     private WorkbenchMegaMenuPresenter menuBar;
 
+    @Mock
+    private DefaultWorkbenchErrorCallback defaultWorkbenchErrorCallback;
+
     private ShowcaseEntryPoint showcaseEntryPoint;
 
     @Before
@@ -80,7 +84,8 @@ public class ShowcaseEntryPointTest {
                                                         identity,
                                                         adminPageHelper,
                                                         menusHelper,
-                                                        menuBar));
+                                                        menuBar,
+                                                        defaultWorkbenchErrorCallback));
         mockMenuHelper();
         mockConstants();
         IocTestingUtils.mockIocManager(iocManager);


### PR DESCRIPTION
This is already merged in 7.7.x. Cherry-picking to master.

Related:
https://github.com/errai/errai/pull/352
https://github.com/kiegroup/appformer/pull/412
https://github.com/kiegroup/kie-wb-common/pull/1951
https://github.com/kiegroup/drools-wb/pull/883
https://github.com/kiegroup/jbpm-wb/pull/1169
https://github.com/kiegroup/optaplanner-wb/pull/290
https://github.com/kiegroup/kie-wb-distributions/pull/776
