### PR TITLE
JBPM-7771 - KIE Server data set editor fails with 'DataSet is empty' …

### DIFF
--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
@@ -112,6 +112,7 @@ public class RemoteDataSetBasicAttributesWorkflow extends DataSetBasicAttributes
             editHandler.lookupDataSet(new DataSetReadyCallback() {
                 @Override
                 public void callback(final DataSet dataSet) {
+                    getDataSetDef().setColumns(dataSet.getDefinition().getColumns());
                     testDataSetCallback.onSuccess(dataSet);
                 }
 


### PR DESCRIPTION
…when being created and data exists

@cristianonicolai it's just one liner to set the columns after loading the data