### PR TITLE
[7.11.x] RHPAM-1542 - KIE Server data set editor fails with 'DataSet is empty'…

### DIFF
--- a/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
+++ b/jbpm-wb-dashboard/jbpm-wb-dashboard-client/src/main/java/org/jbpm/dashboard/dataset/editor/workflow/RemoteDataSetBasicAttributesWorkflow.java
@@ -112,6 +112,7 @@ public class RemoteDataSetBasicAttributesWorkflow extends DataSetBasicAttributes
             editHandler.lookupDataSet(new DataSetReadyCallback() {
                 @Override
                 public void callback(final DataSet dataSet) {
+                    getDataSetDef().setColumns(dataSet.getDefinition().getColumns());
                     testDataSetCallback.onSuccess(dataSet);
                 }
 


### PR DESCRIPTION
… when being created and data exists (#1200)

@cristianonicolai here is a back port for the data set editor issue