### PR TITLE
JBPM-8110: Incorrect log order for events occurring within 1s. Use th…

### DIFF
--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/main/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImpl.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/main/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImpl.java
@@ -298,7 +298,7 @@ public class RemoteTaskServiceImpl extends AbstractKieServerService implements T
                                                                taskId,
                                                                page,
                                                                pageSize,
-                                                               "logTime",
+                                                               "id",
                                                                false);
 
         return events.stream().map(e -> build(e)).collect(toList());

--- a/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/test/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImplTest.java
+++ b/jbpm-wb-human-tasks/jbpm-wb-human-tasks-backend/src/test/java/org/jbpm/workbench/ht/backend/server/RemoteTaskServiceImplTest.java
@@ -272,7 +272,7 @@ public class RemoteTaskServiceImplTest {
                                                    taskId,
                                                    0,
                                                    5,
-                                                   "logTime",
+                                                   "id",
                                                    false)).thenReturn(Arrays.asList(eventInstance));
         List<TaskEventSummary> taskEventSummaries = remoteTaskService.getTaskEvents(serverTemplateId,
                                                                                     containerId,
@@ -283,7 +283,7 @@ public class RemoteTaskServiceImplTest {
                                                       taskId,
                                                       0,
                                                       5,
-                                                      "logTime",
+                                                      "id",
                                                       false);
 
         assertEquals(1,

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
@@ -62,7 +62,7 @@
   {
     "query-name": "jbpmProcessInstanceLogs",
     "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select log.nodeInstanceId, log.nodeId, log.nodeName, log.nodeType, log.externalId, log.processInstanceId, log.log_date, log.connection, log.type, log.workItemId, log.referenceId, log.nodeContainerId, log.sla_due_date, log.slaCompliance from NodeInstanceLog log ",
+    "query-expression": "select log.id, log.nodeId, log.nodeName, log.nodeType, log.externalId, log.processInstanceId, log.log_date, log.connection, log.type, log.workItemId, log.referenceId, log.nodeContainerId, log.sla_due_date, log.slaCompliance from NodeInstanceLog log ",
     "query-target": "CUSTOM"
   }
 ]

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessInstanceLogDataSetConstants.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-api/src/main/java/org/jbpm/workbench/pr/model/ProcessInstanceLogDataSetConstants.java
@@ -20,7 +20,7 @@ public final class ProcessInstanceLogDataSetConstants {
 
     public static final String PROCESS_INSTANCE_LOGS_DATASET = "jbpmProcessInstanceLogs";
 
-    public static final String COLUMN_LOG_ID = "nodeInstanceId";
+    public static final String COLUMN_LOG_ID = "id";
     public static final String COLUMN_LOG_NODE_ID = "nodeId";
     public static final String COLUMN_LOG_NODE_NAME = "nodeName";
     public static final String COLUMN_LOG_NODE_TYPE = "nodeType";

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/log/ProcessInstanceLogFilterSettingsManager.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/log/ProcessInstanceLogFilterSettingsManager.java
@@ -64,7 +64,7 @@ public class ProcessInstanceLogFilterSettingsManager extends FilterSettingsManag
         multipleSortBy.put(COLUMN_LOG_DATE,
                            SortOrder.DESCENDING);
         multipleSortBy.put(COLUMN_LOG_ID,
-                           SortOrder.ASCENDING);
+                           SortOrder.DESCENDING);
         multipleSortBy.put(COLUMN_LOG_TYPE,
                            SortOrder.DESCENDING);
         return multipleSortBy;


### PR DESCRIPTION
…e id gererated by the DB sequence to sort instead the timestamp
- Changed the taskEvents sort field form logTime -> id generated by seq.
- Replaced the nodeinstanceId used at sorting info from process instance log by the id generated by seq.
