### PR TITLE
JBPM-7834: Provide OpenShiftStartupStrategy - WB Integration

### DIFF
--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1311,6 +1311,13 @@
       <groupId>org.kie.workbench.screens</groupId>
       <artifactId>kie-wb-common-server-ui-backend</artifactId>
       <scope>runtime</scope>
+      <exclusions>
+        <exclusion>
+          <!-- Collides with 'xml-apis:xml-apis' -->
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Exclude this module which failed to build after required fabric8 k8s client lib upgrade to 4.1.1

Related PRs:
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/904
- https://github.com/kiegroup/kie-wb-common/pull/2319
- https://github.com/kiegroup/droolsjbpm-integration/pull/1670
- https://github.com/kiegroup/droolsjbpm-integration/pull/1611