### PR TITLE
JBPM-6848: Form Generation fails generating forms for classes on external dependencies

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-backend/pom.xml
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/pom.xml
@@ -156,6 +156,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.kie.workbench.forms</groupId>
+      <artifactId>kie-wb-common-forms-data-modeller-integration-backend</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.jbpm</groupId>
       <artifactId>jbpm-bpmn2</artifactId>
       <scope>test</scope>

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImplTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImplTest.java
@@ -52,6 +52,8 @@ import org.kie.server.client.ProcessServicesClient;
 import org.kie.server.client.UIServicesClient;
 import org.kie.server.client.UserTaskServicesClient;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
+import org.kie.workbench.common.forms.data.modeller.service.ext.ModelReaderService;
+import org.kie.workbench.common.forms.data.modeller.service.impl.ext.dmo.runtime.RuntimeDMOModelReader;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshaller;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshallerRegistry;
@@ -111,6 +113,9 @@ public class FormServiceEntryPointImplTest {
     @Mock
     private KieServicesClient kieServicesClient;
 
+    @Mock
+    private ModelReaderService<ClassLoader> modelReaderService;
+
     private FieldValueMarshallerRegistry registry;
 
     private DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
@@ -147,8 +152,9 @@ public class FormServiceEntryPointImplTest {
 
         backendFormRenderingContextManager = new BackendFormRenderingContextManagerImpl(registry, new ContextModelConstraintsExtractorImpl());
 
-        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
-                                                                          new RawMVELEvaluator());
+        when(modelReaderService.getModelReader(any())).thenReturn(new RuntimeDMOModelReader(this.getClass().getClassLoader(), new RawMVELEvaluator()));
+
+        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(modelReaderService, new TestFieldManager());
 
         dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(runtimeFormGeneratorService);
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormProvidingEngineTest.java
@@ -28,6 +28,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
+import org.kie.workbench.common.forms.data.modeller.service.ext.ModelReaderService;
+import org.kie.workbench.common.forms.data.modeller.service.impl.ext.dmo.runtime.RuntimeDMOModelReader;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshaller;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshallerRegistry;
@@ -55,6 +57,7 @@ import org.mockito.Mock;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.TestCase.assertFalse;
 import static junit.framework.TestCase.assertNotNull;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -65,17 +68,20 @@ public abstract class AbstractFormProvidingEngineTest<SETTINGS extends Rendering
     @Mock
     protected ContentMarshallerContext marshallerContext;
 
-    protected FormDefinitionSerializer formSerializer;
+    @Mock
+    private ModelReaderService<ClassLoader> modelReaderService;
 
-    protected BackendFormRenderingContextManagerImpl contextManager;
+    private FormDefinitionSerializer formSerializer;
+
+    private BackendFormRenderingContextManagerImpl contextManager;
 
     private FieldValueMarshallerRegistry registry;
 
-    protected DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
+    private DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
 
     protected PROCESSOR processor;
 
-    protected SETTINGS settings;
+    private SETTINGS settings;
 
     protected PROVIDER workbenchFormsProvider;
 
@@ -108,8 +114,9 @@ public abstract class AbstractFormProvidingEngineTest<SETTINGS extends Rendering
 
         multipleSubFormFieldValueMarshaller.setRegistry(registry);
 
-        dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(new BPMNRuntimeFormGeneratorService(new TestFieldManager(),
-                                                                                                        new RawMVELEvaluator()));
+        when(modelReaderService.getModelReader(any())).thenReturn(new RuntimeDMOModelReader(this.getClass().getClassLoader(), new RawMVELEvaluator()));
+
+        dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(new BPMNRuntimeFormGeneratorService(modelReaderService, new TestFieldManager()));
 
         contextManager = new BackendFormRenderingContextManagerImpl(registry, new ContextModelConstraintsExtractorImpl());
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
@@ -33,6 +33,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
+import org.kie.workbench.common.forms.data.modeller.service.ext.ModelReaderService;
+import org.kie.workbench.common.forms.data.modeller.service.impl.ext.dmo.runtime.RuntimeDMOModelReader;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshaller;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshallerRegistry;
@@ -61,6 +63,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -87,19 +90,22 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
     @Mock
     protected ContentMarshallerContext marshallerContext;
 
+    @Mock
+    private ModelReaderService<ClassLoader> modelReaderService;
+
     private FieldValueMarshallerRegistry registry;
 
     protected DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
 
-    protected BackendFormRenderingContextManagerImpl backendFormRenderingContextManager;
+    private BackendFormRenderingContextManagerImpl backendFormRenderingContextManager;
 
-    protected BPMNRuntimeFormGeneratorService runtimeFormGeneratorService;
+    private BPMNRuntimeFormGeneratorService runtimeFormGeneratorService;
 
-    protected KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings;
+    private KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings;
 
-    protected SETTINGS renderingSettings;
+    private SETTINGS renderingSettings;
 
-    protected PROCESSOR processor;
+    private PROCESSOR processor;
 
     @Before
     public void init() {
@@ -125,7 +131,7 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
 
         backendFormRenderingContextManager = new BackendFormRenderingContextManagerImpl(registry, new ContextModelConstraintsExtractorImpl());
 
-        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(), new RawMVELEvaluator());
+        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(modelReaderService, new TestFieldManager());
 
         dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(runtimeFormGeneratorService);
 
@@ -136,6 +142,7 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
                                          dynamicBPMNFormGenerator);
 
         when(marshallerContext.getClassloader()).thenReturn(this.getClass().getClassLoader());
+        when(modelReaderService.getModelReader(any())).thenReturn(new RuntimeDMOModelReader(this.getClass().getClassLoader(), new RawMVELEvaluator()));
     }
 
     @Test

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorWithWrongTypesTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorWithWrongTypesTest.java
@@ -31,6 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.kie.internal.task.api.ContentMarshallerContext;
 import org.kie.soup.project.datamodel.commons.util.RawMVELEvaluator;
+import org.kie.workbench.common.forms.data.modeller.service.ext.ModelReaderService;
+import org.kie.workbench.common.forms.data.modeller.service.impl.ext.dmo.runtime.RuntimeDMOModelReader;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.BackendFormRenderingContextManagerImpl;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshaller;
 import org.kie.workbench.common.forms.dynamic.backend.server.context.generation.dynamic.impl.marshalling.FieldValueMarshallerRegistry;
@@ -62,6 +64,7 @@ import org.mockito.Mock;
 import org.uberfire.ext.layout.editor.api.editor.LayoutComponent;
 
 import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -78,21 +81,24 @@ public abstract class AbstractFormsValuesProcessorWithWrongTypesTest<PROCESSOR e
     protected Map<String, String> variables = new HashMap<>();
 
     @Mock
-    ContentMarshallerContext marshallerContext;
+    protected ContentMarshallerContext marshallerContext;
+
+    @Mock
+    private ModelReaderService<ClassLoader> modelReaderService;
 
     private FieldValueMarshallerRegistry registry;
 
-    DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
+    private DynamicBPMNFormGenerator dynamicBPMNFormGenerator;
 
-    BackendFormRenderingContextManagerImpl backendFormRenderingContextManager;
+    private BackendFormRenderingContextManagerImpl backendFormRenderingContextManager;
 
-    BPMNRuntimeFormGeneratorService runtimeFormGeneratorService;
+    private BPMNRuntimeFormGeneratorService runtimeFormGeneratorService;
 
-    KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings;
+    private KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings;
 
-    SETTINGS renderingSettings;
+    private SETTINGS renderingSettings;
 
-    PROCESSOR processor;
+    private PROCESSOR processor;
 
     @Before
     public void init() {
@@ -125,7 +131,7 @@ public abstract class AbstractFormsValuesProcessorWithWrongTypesTest<PROCESSOR e
 
         backendFormRenderingContextManager = new BackendFormRenderingContextManagerImpl(registry, new ContextModelConstraintsExtractorImpl());
 
-        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(new TestFieldManager(), new RawMVELEvaluator());
+        runtimeFormGeneratorService = new BPMNRuntimeFormGeneratorService(modelReaderService, new TestFieldManager());
 
         dynamicBPMNFormGenerator = new DynamicBPMNFormGeneratorImpl(runtimeFormGeneratorService);
 
@@ -134,6 +140,7 @@ public abstract class AbstractFormsValuesProcessorWithWrongTypesTest<PROCESSOR e
                                          dynamicBPMNFormGenerator);
 
         when(marshallerContext.getClassloader()).thenReturn(this.getClass().getClassLoader());
+        when(modelReaderService.getModelReader(any())).thenReturn(new RuntimeDMOModelReader(this.getClass().getClassLoader(), new RawMVELEvaluator()));
     }
 
     @Test


### PR DESCRIPTION
Fixing broken tests due to some api changes.

@tomasdavidorg @cristianonicolai could you please take a look?

This is part of an ensemble, please merge with:
https://github.com/kiegroup/drools/pull/2277
https://github.com/kiegroup/kie-wb-common/pull/2525
https://github.com/kiegroup/jbpm-wb/pull/1316
https://github.com/kiegroup/jbpm-designer/pull/842
https://github.com/kiegroup/kie-wb-distributions/pull/898