### PR TITLE
JBPM-8306: Process diagram images are hardcoded to large sizes

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/diagram/ProcessDiagramWidgetViewImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/diagram/ProcessDiagramWidgetViewImpl.java
@@ -81,8 +81,12 @@ public class ProcessDiagramWidgetViewImpl extends Composite implements ProcessDi
 
         final D3 svg = d3.select("#processDiagramDiv svg");
 
-        double svgWidth = Double.parseDouble(svg.attr("width").toString());
-        double svgHeight = Double.parseDouble(svg.attr("height").toString());
+        String[] viewBoxValues = svg.attr("viewBox").toString().split(" ");
+
+        double svgWidth = Double.parseDouble(viewBoxValues[2]);
+        double svgHeight = Double.parseDouble(viewBoxValues[3]);
+        svg.attr("width", svgWidth);
+        svg.attr("height", svgHeight);
         final D3.Zoom zoom = d3.zoom();
 
         double[] scaleExtent = new double[2];

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/diagram/ProcessDiagramWidgetViewTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/diagram/ProcessDiagramWidgetViewTest.java
@@ -69,8 +69,7 @@ public class ProcessDiagramWidgetViewTest {
         view.setD3Component(d3Mock);
         when(d3Mock.select(anyString())).thenReturn(svgSelect);
         when(d3Mock.zoom()).thenReturn(zoomMock);
-        when(svgSelect.attr("width")).thenReturn(String.valueOf(svgWidth));
-        when(svgSelect.attr("height")).thenReturn(String.valueOf(svgHeight));
+        when(svgSelect.attr("viewBox")).thenReturn("0 0 " + svgWidth + " " + svgHeight);
 
         D3.Event event = mock( D3.Event.class, withSettings().extraInterfaces(ZoomEvent.class));
         ZoomEvent zoomEvent = (ZoomEvent) event; 


### PR DESCRIPTION
work with svg viewBox attribute instead with and height