### PR TITLE
JBPM-8421: Documents tab on Process Instance details doesn't show documents stored in documents variable (updated to support the new "org.jbpm.document.DocumentCollection")

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/util/DocumentsVariableProcessor.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/util/DocumentsVariableProcessor.java
@@ -27,7 +27,13 @@ import static org.jbpm.workbench.pr.backend.server.util.VariableHelper.JBPM_DOCU
 
 public class DocumentsVariableProcessor implements VariableHelper.VariableProcessor {
 
-    private String PATTERN_SUFFIX = "+\\s\\(\\d+/\\d+\\)";
+    private static final String PATTERN_SUFFIX = "+\\s\\(\\d+/\\d+\\)";
+
+    private String type;
+
+    public DocumentsVariableProcessor(String type) {
+        this.type = type;
+    }
 
     @Override
     public void process(long processInstanceId, String varName, String varType, List<VariableInstance> variables, Consumer<ProcessVariableSummary> consumer) {
@@ -45,6 +51,6 @@ public class DocumentsVariableProcessor implements VariableHelper.VariableProces
 
     @Override
     public String getSupportedType() {
-        return VariableHelper.JBPM_DOCUMENTS;
+        return type;
     }
 }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/util/VariableHelper.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/util/VariableHelper.java
@@ -35,16 +35,21 @@ public class VariableHelper {
     public static final Collection<String> DOCUMENT_TYPES;
 
     public static final String JBPM_DOCUMENT = "org.jbpm.document.Document";
-    public static final String JBPM_DOCUMENTS = "org.jbpm.document.Documents";
+
+    public static final String DOCUMENT_COLLECTION = "org.jbpm.document.DocumentCollection";
+    public static final String DOCUMENT_COLLECTION_IMPL = "org.jbpm.document.service.impl.DocumentCollectionImpl";
+    public static final String LEGACY_DOCUMENTS = "org.jbpm.document.Documents";
 
     private static final List<String> excludedVariables = Collections.singletonList("processId");
 
     private static final Map<String, VariableProcessor> processors = new HashMap<>();
 
     static {
-        DOCUMENT_TYPES = Arrays.asList(JBPM_DOCUMENT, JBPM_DOCUMENTS);
+        DOCUMENT_TYPES = Arrays.asList(JBPM_DOCUMENT, DOCUMENT_COLLECTION, DOCUMENT_COLLECTION_IMPL, LEGACY_DOCUMENTS);
 
-        registerProcessor(new DocumentsVariableProcessor());
+        registerProcessor(new DocumentsVariableProcessor(DOCUMENT_COLLECTION));
+        registerProcessor(new DocumentsVariableProcessor(DOCUMENT_COLLECTION_IMPL));
+        registerProcessor(new DocumentsVariableProcessor(LEGACY_DOCUMENTS));
     }
 
     public static void registerProcessor(VariableProcessor processor) {
@@ -57,7 +62,7 @@ public class VariableHelper {
                                                                String deploymentId,
                                                                String serverTemplateId) {
 
-            List<VariableInstance> filteredVariables = variables.stream()
+        List<VariableInstance> filteredVariables = variables.stream()
                 .filter(variable -> !excludedVariables.contains(variable.getVariableName()))
                 .collect(Collectors.toList());
 

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/RemoteProcessVariablesServiceImplTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/test/java/org/jbpm/workbench/pr/backend/server/RemoteProcessVariablesServiceImplTest.java
@@ -143,13 +143,27 @@ public class RemoteProcessVariablesServiceImplTest {
     }
 
     @Test
-    public void getProcessVariablesWithDocumentsTestWithContainerStarted() {
+    public void testGetProcessVariablesWithDocumentCollectionWithContainerStarted() {
+        testDocumentCollection(VariableHelper.DOCUMENT_COLLECTION);
+    }
 
-        HashMap processDefVars = new HashMap();
+    @Test
+    public void testGetProcessVariablesWithDocumentCollectionImplWithContainerStarted() {
+        testDocumentCollection(VariableHelper.DOCUMENT_COLLECTION_IMPL);
+    }
+
+    @Test
+    public void testGetProcessVariablesWithLegacyDocumentsWithContainerStarted() {
+        testDocumentCollection(VariableHelper.LEGACY_DOCUMENTS);
+    }
+
+    public void testDocumentCollection(final String documentsCollectionType) {
+
+        HashMap<String, String> processDefVars = new HashMap<>();
         processDefVars.put(var1, "");
         processDefVars.put(var2, "");
         processDefVars.put(doc, VariableHelper.JBPM_DOCUMENT);
-        processDefVars.put(docs, VariableHelper.JBPM_DOCUMENTS);
+        processDefVars.put(docs, documentsCollectionType);
 
         VariablesDefinition variablesDefinition = new VariablesDefinition(processDefVars);
 
@@ -208,7 +222,6 @@ public class RemoteProcessVariablesServiceImplTest {
         assertEquals(var2, processInstanceVariables.get(4).getName());
         assertEquals("", processInstanceVariables.get(4).getNewValue());
     }
-
 
     @Test
     public void getProcessVariablesTestWithContainerStopped() {


### PR DESCRIPTION
@cristianonicolai @nmirasch @tomasdavidorg this PR includes the support for the new DocumentCollection type which was not included on the previous PR. Sorry about this...

This is part of an ensemble, please merge with:
https://github.com/kiegroup/jbpm/pull/1480
https://github.com/kiegroup/jbpm-wb/pull/1346