### PR TITLE
RHPAM-1549 - Missing translations in the UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,6 @@
     <spotbugs.failOnViolation>true</spotbugs.failOnViolation>
     <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     <checkstyle.logViolationsToConsole>true</checkstyle.logViolationsToConsole>
-    <needs-errai-1101-workaround>true</needs-errai-1101-workaround>
   </properties>
 
   <modules>
@@ -230,6 +229,30 @@
             </configuration>
         </plugin>
 
+      <!-- Temporary workaround for https://issues.jboss.org/browse/ERRAI-1101. Needs to stay here until
+        we find a general solution (e.g. moving all localized code to Errai TranslationService. -->
+
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-default-i18n-resource</id>
+            <phase>process-resources</phase>
+            <configuration>
+              <target>
+                <copy todir="${project.build.directory}/classes"
+                      includeemptydirs="false" failonerror="false" quiet="true">
+                  <fileset dir="${project.build.directory}/classes"/>
+                  <globmapper from="*Constants.properties" to="*Constants_default.properties"/>
+                </copy>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>
         <configuration>


### PR DESCRIPTION
needs-errai-1101-workaround maven profile added on the below mentioned PR’s (Earlier PR’s) seemed to be not applying on all the child maven modules. In this change, the implementation of the plugin is copied explicitly into all the relevant root project folders which will invoke the plugin for all the child modules.

What Plugin does

It creates a file CONSTANT_DEFAULT.properties for all the properties file we are using, so that in case the translation of a text is not given for a particular language, it uses the CONSTANT_DEFAULT.properties as a fallback for translation.

Please check this for reference

Actual issue: https://issues.jboss.org/browse/ERRAI-1101
Earlier PR’s:

https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/729
kiegroup/appformer/pull/267
kiegroup/droolsjbpm-build-bootstrap/pull/729
kiegroup/kie-wb-common/pull/1553
kiegroup/drools-wb/pull/837
kiegroup/jbpm-wb/pull/1026
kiegroup/optaplanner-wb/pull/268
kiegroup/kie-wb-distributions/pull/720

Related PR's
https://github.com/kiegroup/drools-wb/pull/1142
https://github.com/kiegroup/optaplanner-wb/pull/336
https://github.com/kiegroup/jbpm-wb/pull/1351
https://github.com/kiegroup/kie-wb-distributions/pull/924
https://github.com/kiegroup/kie-wb-common/pull/2647
https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/954