### PR TITLE
JBPM-8742: Link column preferences with saved filter

### DIFF
--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractMultiGridPresenter.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractMultiGridPresenter.java
@@ -272,7 +272,15 @@ public abstract class AbstractMultiGridPresenter<T extends GenericSummary, V ext
         settings.setTableName(filterName);
         settings.setTableDescription(filterName);
         filterSettingsManager.saveFilterIntoPreferences(settings,
-                                                        state -> callback.accept(state ? null : Constants.INSTANCE.FilterWithSameNameAlreadyExists()));
+                                                        state -> {
+                                                            if (state) {
+                                                                getListView().getListGrid().getGridPreferencesStore().setPreferenceKey(settings.getKey());
+                                                                getListView().getListGrid().saveGridToUserPreferences();
+                                                                callback.accept(null);
+                                                            } else {
+                                                                callback.accept(Constants.INSTANCE.FilterWithSameNameAlreadyExists());
+                                                            }
+                                                        });
     }
 
     protected Optional<String> getSearchParameter(final String parameterId) {

--- a/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractMultiGridView.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/main/java/org/jbpm/workbench/common/client/list/AbstractMultiGridView.java
@@ -193,9 +193,10 @@ public abstract class AbstractMultiGridView<T extends GenericSummary, V extends 
                 addNewTableToColumn(newListGrid);
 
                 listTable = newListGrid;
+                listTable.setPersistPreferencesOnChange(false);
 
                 reloadColumnSortList();
-                
+
                 readyCallback.accept(listTable);
             }).loadUserPreferences(key, UserPreferencesType.GRIDPREFERENCES);
         }, error -> new DefaultWorkbenchErrorCallback().error(error));
@@ -225,7 +226,7 @@ public abstract class AbstractMultiGridView<T extends GenericSummary, V extends 
                                                       newListGrid);
     }
 
-    protected Column initGenericColumn(final String key){
+    protected Column initGenericColumn(final String key) {
         return null;
     }
 
@@ -250,12 +251,12 @@ public abstract class AbstractMultiGridView<T extends GenericSummary, V extends 
     public void initSelectionModel(final ListTable<T> extendedPagedTable) {
         extendedPagedTable.setEmptyTableCaption(getEmptyTableCaption());
         extendedPagedTable.setSelectionCallback((s) -> presenter.selectSummaryItem(s));
-        if(hasBulkActions()) {
+        if (hasBulkActions()) {
             initBulkActions(extendedPagedTable);
         }
     }
 
-    protected boolean hasBulkActions(){
+    protected boolean hasBulkActions() {
         return true;
     }
 

--- a/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/list/AbstractMultiGridPresenterTest.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/list/AbstractMultiGridPresenterTest.java
@@ -42,6 +42,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import org.uberfire.ext.services.shared.preferences.GridPreferencesStore;
 import org.uberfire.ext.widgets.common.client.breadcrumbs.UberfireBreadcrumbs;
 import org.uberfire.mocks.EventSourceMock;
 
@@ -198,7 +199,6 @@ public class AbstractMultiGridPresenterTest {
         
         verify(dataSetQueryHelper, never()).setLastOrderedColumn(any());
         verify(dataSetQueryHelper, never()).setLastSortOrder(any());
-        
     }
 
     @Test
@@ -214,6 +214,26 @@ public class AbstractMultiGridPresenterTest {
 
         verify(dataSetQueryHelper).setLastOrderedColumn(column);
         verify(dataSetQueryHelper).setLastSortOrder(SortOrder.ASCENDING);
+    }
 
+    @Test
+    public void testSaveSearchFilterSettings() {
+        String key = "key";
+        ListTable listTable = mock(ListTable.class);
+        GridPreferencesStore gridPreferencesStore = mock(GridPreferencesStore.class);
+
+        when(dataSetQueryHelper.getCurrentTableSettings()).thenReturn(filterSettingsMock);
+        when(filterSettingsMock.getKey()).thenReturn(key);
+        when(listView.getListGrid()).thenReturn(listTable);
+        when(listTable.getGridPreferencesStore()).thenReturn(gridPreferencesStore);
+
+        presenter.saveSearchFilterSettings("filterName", mock(Consumer.class));
+
+        ArgumentCaptor<Consumer> booleanConsumerCaptor = ArgumentCaptor.forClass(Consumer.class);
+        verify(filterSettingsManager).saveFilterIntoPreferences(eq(filterSettingsMock),
+                                                                booleanConsumerCaptor.capture());
+        booleanConsumerCaptor.getValue().accept(true);
+        verify(gridPreferencesStore).setPreferenceKey(key);
+        verify(listTable).saveGridToUserPreferences();
     }
 }

--- a/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/list/AbstractMultiGridViewTest.java
+++ b/jbpm-wb-common/jbpm-wb-common-client/src/test/java/org/jbpm/workbench/common/client/list/AbstractMultiGridViewTest.java
@@ -228,7 +228,7 @@ public abstract class AbstractMultiGridViewTest<T extends GenericSummary> {
         getView().loadListTable("key", consumer);
     }
 
-    public static Column newColumnMock(final String dataStoreName){
+    public static Column newColumnMock(final String dataStoreName) {
         Column column = mock(Column.class);
         when(column.getCell()).thenReturn(mock(Cell.class));
         when(column.getDataStoreName()).thenReturn(dataStoreName);
@@ -321,5 +321,21 @@ public abstract class AbstractMultiGridViewTest<T extends GenericSummary> {
         //sort list with column
         assertEquals("test", getView().getSortColumn());
         assertEquals(true, getView().isSortAscending());
+    }
+
+    @Test
+    public void testSetPersistOnPreferencesChangeAfterLoadListTable() {
+        doAnswer((InvocationOnMock inv) -> {
+            ((ParameterizedCommand<ManagePreferences>) inv.getArguments()[0]).execute(new ManagePreferences().defaultValue(new ManagePreferences()));
+            return null;
+        }).when(preferences).load(any(ParameterizedCommand.class), any(ParameterizedCommand.class));
+
+        Consumer<ListTable> consumer = table -> {
+            assertEquals(ManagePreferences.DEFAULT_PAGINATION_OPTION.intValue(),
+                         table.getGridPreferencesStore().getPageSizePreferences());
+            assertFalse(table.isPersistingPreferencesOnChange());
+        };
+
+        getView().loadListTable("key", consumer);
     }
 }


### PR DESCRIPTION
depends on https://github.com/kiegroup/appformer/pull/789.
Only store grid preferences(column arrangement) when save filter operation is performed. Only load stored grid preferences when a saved filter is loaded.