### PR TITLE
Use containsOnly instead of containsExactly in ProcessInstanceListBasicFiltersPresenterTest

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/list/ProcessInstanceListBasicFiltersPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/list/ProcessInstanceListBasicFiltersPresenterTest.java
@@ -84,7 +84,7 @@ public class ProcessInstanceListBasicFiltersPresenterTest extends AbstractBasicF
         ArgumentCaptor<Map> slaDescriptionsCaptors = ArgumentCaptor.forClass(Map.class);
         verify(getView()).addSelectFilter(anyString(), slaDescriptionsCaptors.capture(), any());
         final Map<String, String> slaDescriptions = slaDescriptionsCaptors.getValue();
-        assertThat(slaDescriptions).containsExactly(
+        assertThat(slaDescriptions).containsOnly(
                 immutableEntry(String.valueOf(ProcessInstance.SLA_NA), commonConstants.INSTANCE.SlaNA()),
                 immutableEntry(String.valueOf(ProcessInstance.SLA_PENDING), commonConstants.SlaPending()),
                 immutableEntry(String.valueOf(ProcessInstance.SLA_MET), commonConstants.SlaMet()),


### PR DESCRIPTION
The test in `org.jbpm.workbench.pr.client.editors.instance.list.ProcessInstanceListBasicFiltersPresenterTest#testSlaComplianceFilters` can fail due to a different iteration order of `HashMap`. The failure is presented as follows:
`java.lang.AssertionError: `
`Actual and expected have the same elements but not in the same order, at index 0 actual element was:`
  `<MapEntry[key="1", value="SlaPending"]>`
`whereas expected element was:`
 ` <0=SlaNA>`

The initialization location of the that `HashMap` is `org.jbpm.workbench.common.client.util.SlaStatusConverter.getSLAComplianceAliasMap(SlaStatusConverter.java:72)`
`Map<String, String> aliasMap = new HashMap();`

The specification about `HashMap` says that "this class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

The fix is to use `containsOnly` instead of `containsExactly` so that the order of entries in `HashMap` will not make the assertion fail. In this way, the test can be more robust, and the failure above is removed.