### PR TITLE
Use containsOnly insead of containsExactly in ProcessInstanceDiagramPresenterTest.java

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/diagram/ProcessInstanceDiagramPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/diagram/ProcessInstanceDiagramPresenterTest.java
@@ -238,7 +238,7 @@ public class ProcessInstanceDiagramPresenterTest {
         ArgumentCaptor<Map> badgesInstancesCaptor = ArgumentCaptor.forClass(Map.class);
         verify(view).setNodeBadges(badgesInstancesCaptor.capture());
         final Map<String, Long> badges = badgesInstancesCaptor.getValue();
-        assertThat(badges).containsExactly(immutableEntry("_1", 1l), immutableEntry("_2", 1l), immutableEntry("_3", 1l), immutableEntry("_4", 1l));
+        assertThat(badges).containsOnly(immutableEntry("_1", 1l), immutableEntry("_2", 1l), immutableEntry("_3", 1l), immutableEntry("_4", 1l));
     }
 
     @Test


### PR DESCRIPTION
The test in `org.jbpm.workbench.pr.client.editors.instance.diagram.ProcessInstanceDiagramPresenterTest#testOnProcessInstanceSelectionEvent` can fail due to a different iteration order of `Map`. The failure is presented as follows:
`java.lang.AssertionError:`
`Actual and expected have the same elements but not in the same order, at index 0 actual element was:`
 `<MapEntry[key="_2", value=1L]>`
`whereas expected element was:`
  `<_1=1>`

The fix is to use `containsOnly` instead of `containsExactly` so that the iteration order of `Map` does not make the assertion fail. In this way, the test will be more robust, and the failure above will be removed.