### PR TITLE
fixed real directory for Errai Wildfly distribution

### DIFF
--- a/jbpm-wb-integration/jbpm-wb-integration-backend/pom.xml
+++ b/jbpm-wb-integration/jbpm-wb-integration-backend/pom.xml
@@ -32,7 +32,7 @@
 
   <properties>
     <java.module.name>org.jbpm.wb.integration.backend</java.module.name>
-    <jboss.home>${project.build.directory}/wildfly-${version.org.jboss.errai.wildfly}</jboss.home>
+    <jboss.home>${project.build.directory}/wildfly-${version.org.wildfly}</jboss.home>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This is a change for having always directory for Errai Wildfly unpacked distribution to be on the same name as original wildfly distribution as Errai just repackaged it so naming directory to that version is not confusing