### PR TITLE
JBPM-9286 UI error when parent process instance details have been rem…

### DIFF
--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-backend/src/main/java/org/jbpm/workbench/pr/backend/server/RemoteProcessRuntimeDataServiceImpl.java
@@ -149,9 +149,7 @@ public class RemoteProcessRuntimeDataServiceImpl extends AbstractKieServerServic
         summary.setSubProcessInstances(getProcessInstancesByParentId(processInstanceKey, processInstanceKey.getDeploymentId()));
 
         if (processInstance.getParentId() != -1) {
-            QueryServicesClient queryServicesClient = getClient(processInstanceKey.getServerTemplateId(), QueryServicesClient.class);
-            summary.setParentProcessInstanceSummary(new ProcessInstanceSummaryMapper(processInstanceKey.getServerTemplateId())
-                                                            .apply(queryServicesClient.findProcessInstanceById(processInstance.getParentId())));
+            summary.setParentProcessInstanceSummary(getProcessInstance(new ProcessInstanceKey(processInstanceKey.getServerTemplateId(), "", processInstance.getParentId())));
         } else {
             summary.setParentProcessInstanceSummary(null);
         }

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenter.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/main/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenter.java
@@ -82,8 +82,7 @@ public class ProcessInstanceDetailsTabPresenter implements ProcessInstanceSummar
         view.setProcessDeploymentText(process.getDeploymentId());
         view.setCorrelationKeyText(process.getCorrelationKey());
         if (process.getParentId() > 0) {
-            view.setParentProcessInstanceIdText(process.getParentId().toString(), true);
-            view.setProcessInstanceDetailsCallback(() -> onProcessInstanceIdSelected(process.getServerTemplateId(), process.getDeploymentId(), process.getParentId()));
+            setParentInstance(process);
         } else {
             view.setParentProcessInstanceIdText(constants.No_Parent_Process_Instance(), false);
         }
@@ -110,6 +109,17 @@ public class ProcessInstanceDetailsTabPresenter implements ProcessInstanceSummar
                     view.setCurrentActivitiesListBox(safeHtmlBuilder.toSafeHtml().asString());
                 }
         ).getProcessInstanceActiveNodes(process.getProcessInstanceKey());
+    }
+
+    protected void setParentInstance(ProcessInstanceSummary process) {
+        processRuntimeDataService.call((ProcessInstanceSummary pi) -> {
+            if (pi != null) {
+                view.setParentProcessInstanceIdText(process.getParentId().toString(), true);
+                view.setProcessInstanceDetailsCallback(() -> onProcessInstanceIdSelected(process.getServerTemplateId(), process.getDeploymentId(), process.getParentId()));
+            } else {
+                view.setParentProcessInstanceIdText(process.getParentId().toString(), false);
+            }
+        }).getProcessInstance(new ProcessInstanceKey(process.getServerTemplateId(), "", process.getParentId()));
     }
 
     public void onProcessInstanceIdSelected(String serverTemplateId, String processDeploymentId, Long parentId) {

--- a/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenterTest.java
+++ b/jbpm-wb-process-runtime/jbpm-wb-process-runtime-client/src/test/java/org/jbpm/workbench/pr/client/editors/instance/details/ProcessInstanceDetailsTabPresenterTest.java
@@ -76,7 +76,11 @@ public class ProcessInstanceDetailsTabPresenterTest {
     }
 
     @Test
-    public void setProcessInstanceDetailsTest() {
+    public void setProcessInstanceDetailsTestWihtParentProcessInstance() {
+        ProcessInstanceSummary parentProcessInstanceSummary = getProcessInstanceSummary();
+        parentProcessInstanceSummary.setParentId(null);
+        parentProcessInstanceSummary.setProcessInstanceId(1L);
+        when(processRuntimeDataServiceMock.getProcessInstance(any())).thenReturn(getProcessInstanceSummary());
         presenter.setProcessInstance(processInstanceSummary);
 
         verify(view).setProcessDefinitionIdText(processInstanceSummary.getProcessId());
@@ -86,8 +90,8 @@ public class ProcessInstanceDetailsTabPresenterTest {
         verify(view).setCorrelationKeyText(processInstanceSummary.getCorrelationKey());
         verify(view).setSlaComplianceText(org.jbpm.workbench.common.client.resources.i18n.Constants.INSTANCE.SlaMet());
         verify(view).setProcessInstanceDetailsCallback(any());
-        verify(view, times(1)).setParentProcessInstanceIdText("", false);
-        verify(view, times(1)).setParentProcessInstanceIdText("1", true);
+        verify(view).setParentProcessInstanceIdText("", false);
+        verify(view).setParentProcessInstanceIdText("1", true);
         ArgumentCaptor<String> argumentCaptor = ArgumentCaptor.forClass(String.class);
         verify(view, times(2)).setActiveTasksListBox(argumentCaptor.capture());
 
@@ -109,6 +113,15 @@ public class ProcessInstanceDetailsTabPresenterTest {
                           String.valueOf(nodeInstanceSummary.getId()),
                           nodeInstanceSummary.getName(),
                           nodeInstanceSummary.getType());
+    }
+
+    @Test
+    public void setProcessInstanceDetailsTestWihtoutParentProcessInstance() {
+        when(processRuntimeDataServiceMock.getProcessInstance(any())).thenReturn(null);
+        presenter.setProcessInstance(processInstanceSummary);
+
+        verify(view).setParentProcessInstanceIdText("", false);
+        verify(view).setParentProcessInstanceIdText("1", false);
     }
 
     private NodeInstanceSummary getNodeInstanceSummary() {


### PR DESCRIPTION
…oved

**Thank you for submitting this pull request**

**JIRA**: _(JBPM-9286)_ 

[link](https://issues.redhat.com/browse/JBPM-9286)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

https://github.com/kiegroup/droolsjbpm-integration/pull/2193

**How to retest or run**:

* a pull request please add comment: regex **[.\*[j|J]enkins,?.\*(retest|test) this.\*]**

* a full downstream build please add comment: regex **[.*\[j|J]enkins,?.\*(execute|run|trigger|start|do) fdb.\*]**

* a compile downstream build please  add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) cdb.\*]**

* a full production downstream please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) product fdb.\*]**

* an upstream build please add comment: regex **[.\*[j|J]enkins,?.\*(execute|run|trigger|start|do) upstream.\*]**

i.e for running a full downstream build =  **Jenkins do fdb**
