### PR TITLE
RHPAM-3292: KIE Server data set editor fails

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
@@ -78,8 +78,8 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                                                               QueryServicesClient.class);
 
             QueryDefinition definition = queryClient.getQuery(def.getUUID());
-            if (definition.getColumns() != null) {
-                addColumnsToDefinition(def, definition);
+            if (definition != null) {
+                addColumnsToDefinition(def, definition.getColumns());
             }
         }
         List<DataColumnDef> columns = def.getColumns();
@@ -253,7 +253,9 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
         } else {
             if (def.getColumns() != null && def.getColumns().isEmpty()) {
                 QueryDefinition query = queryClient.getQuery(def.getUUID());
-                addColumnsToDefinition(def, query);
+                if (query != null) {
+                    addColumnsToDefinition(def, query.getColumns());
+                }
             }
             return queryClient.query(
                     dataSetLookup.getDataSetUUID(),
@@ -417,7 +419,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
         
         DataColumnDef column = def.getColumnById(groupFunction.getColumnId());
         if (column == null) {
-            column =  def.getColumnById(groupFunction.getSourceId());
+            column = def.getColumnById(groupFunction.getSourceId());
         }
         ColumnType type = column.getColumnType();
         if(type != ColumnType.DATE || columnGroup == null || groupFunction == null){
@@ -427,9 +429,8 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
         }
     }
     
-    protected void addColumnsToDefinition(DataSetDef def, QueryDefinition queryDef) {
-        if (queryDef != null && queryDef.getColumns() != null) {
-            Map<String, String> columns = queryDef.getColumns();
+    protected void addColumnsToDefinition(DataSetDef def, Map<String, String> columns) {
+        if (columns != null) {
             columns.entrySet().stream()
                    .filter(e -> def.getColumnById(e.getKey()) == null)
                    .forEach(e -> def.addColumn(e.getKey(), ColumnType.valueOf(e.getValue())));

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
@@ -20,7 +20,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+
 import javax.enterprise.context.ApplicationScoped;
 
 import org.dashbuilder.dataprovider.DataSetProvider;
@@ -77,13 +79,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
 
             QueryDefinition definition = queryClient.getQuery(def.getUUID());
             if (definition.getColumns() != null) {
-
-                for (Entry<String, String> entry : definition.getColumns().entrySet()) {
-                    if (def.getColumnById(entry.getKey()) == null) {
-                        def.addColumn(entry.getKey(),
-                                      ColumnType.valueOf(entry.getValue()));
-                    }
-                }
+                addColumnsToDefinition(def, definition);
             }
         }
         List<DataColumnDef> columns = def.getColumns();
@@ -255,6 +251,10 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                 throw new RuntimeException(e);
             }
         } else {
+            if (def.getColumns() != null && def.getColumns().isEmpty()) {
+                QueryDefinition query = queryClient.getQuery(def.getUUID());
+                addColumnsToDefinition(def, query);
+            }
             return queryClient.query(
                     dataSetLookup.getDataSetUUID(),
                     QueryServicesClient.QUERY_MAP_RAW,
@@ -414,11 +414,25 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
     protected ColumnType getGroupFunctionColumnType(final DataSetDef def,
                                                     final ColumnGroup columnGroup,
                                                     final GroupFunction groupFunction) {
-        ColumnType type = def.getColumnById(groupFunction.getColumnId()).getColumnType();
+        
+        DataColumnDef column = def.getColumnById(groupFunction.getColumnId());
+        if (column == null) {
+            column =  def.getColumnById(groupFunction.getSourceId());
+        }
+        ColumnType type = column.getColumnType();
         if(type != ColumnType.DATE || columnGroup == null || groupFunction == null){
             return type;
         } else {
             return columnGroup.getSourceId().equals(groupFunction.getSourceId()) ? ColumnType.LABEL : type;
+        }
+    }
+    
+    protected void addColumnsToDefinition(DataSetDef def, QueryDefinition queryDef) {
+        if (queryDef != null && queryDef.getColumns() != null) {
+            Map<String, String> columns = queryDef.getColumns();
+            columns.entrySet().stream()
+                   .filter(e -> def.getColumnById(e.getKey()) == null)
+                   .forEach(e -> def.addColumn(e.getKey(), ColumnType.valueOf(e.getValue())));
         }
     }
 }

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerDataSetProviderTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerDataSetProviderTest.java
@@ -16,6 +16,7 @@
 package org.jbpm.workbench.ks.integration;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -79,6 +80,9 @@ public class KieServerDataSetProviderTest {
 
     @Mock
     RemoteDataSetDef dataSetDef;
+
+    @Mock
+    QueryDefinition queryDef;
 
     @Before
     public void setUp() {
@@ -278,6 +282,8 @@ public class KieServerDataSetProviderTest {
     
     @Test
     public void testPerformQueryRegularMode() {
+        String columnId = "test";
+        String columnType = "LABEL";
         QueryFilterSpec filterSpec = new QueryFilterSpec();
         
         ConsoleDataSetLookup dataSetLookup = Mockito.mock(ConsoleDataSetLookup.class);
@@ -285,6 +291,9 @@ public class KieServerDataSetProviderTest {
         when(dataSetLookup.getNumberOfRows()).thenReturn(10);
         when(dataSetLookup.getRowOffset()).thenReturn(1);
         when(dataSetLookup.getDataSetUUID()).thenReturn("");
+        
+        when(queryDef.getColumns()).thenReturn(Collections.singletonMap(columnId, columnType));
+        when(queryServicesClient.getQuery(any())).thenReturn(queryDef);
         
         kieServerDataSetProvider.performQuery(dataSetDef, dataSetLookup, queryServicesClient, filterSpec);
         
@@ -298,6 +307,8 @@ public class KieServerDataSetProviderTest {
                                           anyInt(),
                                           anyInt(),
                                           any());
+        
+        verify(dataSetDef).addColumn(eq(columnId), eq(ColumnType.LABEL));
     }    
     
     @Test


### PR DESCRIPTION
RHPAM-3292: KIE Server data set editor fails with 'Java Runtime Exception' when trying to hit the Test button second time
--

The root cause for this issue was that columns were not added to the def when doing the first query execution from the dataset editor.

The solution is add the columns to the dataset definition.