### PR TITLE
JBPM-9601: Stunner - Business Rule and Decision tasks are missing in Case Project by default

### DIFF
--- a/jbpm-wb-integration/jbpm-wb-integration-backend/src/main/resources/WorkDefinition.wid
+++ b/jbpm-wb-integration/jbpm-wb-integration-backend/src/main/resources/WorkDefinition.wid
@@ -1,5 +1,36 @@
 [
     [
+        "name" : "BusinessRuleTask",
+        "displayName" : "BusinessRuleTask",
+        "category" : "jbpm-workitems-bpmn2",
+        "description" : "",
+        "defaultHandler" : "mvel: new org.jbpm.process.workitem.bpmn2.BusinessRuleTaskHandler()",
+        "documentation" : "jbpm-workitems-bpmn2/index.html",
+        "icon" : "BusinessRuleTask.png",
+
+        "parameters" : [
+            "KieSessionName" : new StringDataType(),
+            "KieSessionType" : new StringDataType()
+        ]
+    ],
+
+    [
+        "name" : "DecisionTask",
+        "displayName" : "Decision Task",
+        "category" : "jbpm-workitems-bpmn2",
+        "description" : "",
+        "defaultHandler" : "mvel: new org.jbpm.process.workitem.bpmn2.DecisionTaskHandler()",
+        "documentation" : "jbpm-workitems-bpmn2/index.html",
+        "icon" : "DecisionTask.png",
+
+        "parameters" : [
+            "Model" : new StringDataType(),
+            "Namespace" : new StringDataType(),
+            "Decision" : new StringDataType()
+        ]
+    ],
+
+    [
         "name" : "Email",
         "displayName" : "Email",
         "category" : "jbpm-workitems-email",


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [JBPM-9601](https://issues.redhat.com/browse/JBPM-9601)

**Business Central**: [WAR](https://drive.google.com/file/d/1Yy6azr5QxYlITlTH0caHS0st_uBbx83P/view?usp=sharing)

Hi @romartin, @LuboTerifaj, there is an update of Case Project WID file. It adds only Business Rule and Decision tasks as discussed.

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
