### PR TITLE
AF-2811: Required Process Variable Tags shouldn't be accepted in forms when empty

### DIFF
--- a/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/ProcessRenderingSettings.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/ProcessRenderingSettings.java
@@ -25,6 +25,7 @@ public class ProcessRenderingSettings implements RenderingSettings {
 
     private ProcessDefinition process;
     private Map<String, String> processData;
+    private Map<String, String[]> processVariableTags;
     private String serverTemplateId;
     private String formContent;
     private ContentMarshallerContext marshallerContext;
@@ -36,6 +37,20 @@ public class ProcessRenderingSettings implements RenderingSettings {
                                     ContentMarshallerContext marshallerContext) {
         this.process = process;
         this.processData = processData;
+        this.serverTemplateId = serverTemplateId;
+        this.formContent = formContent;
+        this.marshallerContext = marshallerContext;
+    }
+
+    public ProcessRenderingSettings(ProcessDefinition process,
+                                    Map<String, String> processData,
+                                    Map<String, String[]> processVariableTags,
+                                    String serverTemplateId,
+                                    String formContent,
+                                    ContentMarshallerContext marshallerContext) {
+        this.process = process;
+        this.processData = processData;
+        this.processVariableTags = processVariableTags;
         this.serverTemplateId = serverTemplateId;
         this.formContent = formContent;
         this.marshallerContext = marshallerContext;
@@ -55,6 +70,15 @@ public class ProcessRenderingSettings implements RenderingSettings {
 
     public void setProcessData(Map<String, String> processData) {
         this.processData = processData;
+    }
+
+    @Override
+    public Map<String, String[]> getProcessVariableTags() {
+        return processVariableTags;
+    }
+
+    public void setProcessVariableTags(Map<String, String[]> processVariableTags) {
+        this.processVariableTags = processVariableTags;
     }
 
     @Override

--- a/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/RenderingSettings.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/RenderingSettings.java
@@ -17,6 +17,7 @@
 package org.jbpm.workbench.forms.service.providing;
 
 import java.io.Serializable;
+import java.util.Map;
 
 import org.kie.internal.task.api.ContentMarshallerContext;
 
@@ -49,4 +50,9 @@ public interface RenderingSettings extends Serializable {
      * Sets the ContentMarshallerContext
      */
     void setMarshallerContext(ContentMarshallerContext marshallerContext);
+
+    /**
+     * Returns the ProcessVariables Tags info
+     */
+    Map<String, String[]> getProcessVariableTags();
 }

--- a/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/TaskRenderingSettings.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-api/src/main/java/org/jbpm/workbench/forms/service/providing/TaskRenderingSettings.java
@@ -92,4 +92,9 @@ public class TaskRenderingSettings implements RenderingSettings {
     public void setMarshallerContext(ContentMarshallerContext marshallerContext) {
         this.marshallerContext = marshallerContext;
     }
+
+    @Override
+    public Map<String, String[]> getProcessVariableTags() {
+        return null;
+    }
 }

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImpl.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/FormServiceEntryPointImpl.java
@@ -283,6 +283,7 @@ public class FormServiceEntryPointImpl extends AbstractKieServerService implemen
                                                                     processId);
             ProcessRenderingSettings settings = new ProcessRenderingSettings(processDesc,
                                                                              processData,
+                                                                             processDefinition.getTagsByVariable(),
                                                                              serverTemplateId,
                                                                              formContent,
                                                                              new ContentMarshallerContext(null,
@@ -306,6 +307,7 @@ public class FormServiceEntryPointImpl extends AbstractKieServerService implemen
         return renderDefaultProcessForm(serverTemplateId,
                                         processDesc,
                                         processData,
+                                        processDefinition.getTagsByVariable(),
                                         kieServicesClient);
     }
 
@@ -326,10 +328,12 @@ public class FormServiceEntryPointImpl extends AbstractKieServerService implemen
     private FormRenderingSettings renderDefaultProcessForm(String serverTemplateId,
                                                            org.jbpm.workbench.forms.service.providing.model.ProcessDefinition processDesc,
                                                            Map<String, String> processData,
+                                                           Map<String, String[]> tagsByVariable,
                                                            KieServicesClient kieServicesClient) {
         try {
             return defaultFormProvider.render(new ProcessRenderingSettings(processDesc,
                                                                            processData,
+                                                                           tagsByVariable,
                                                                            serverTemplateId,
                                                                            "",
                                                                            new ContentMarshallerContext(null,

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessor.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/main/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessor.java
@@ -16,6 +16,7 @@
 
 package org.jbpm.workbench.forms.display.backend.provider;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -98,6 +99,12 @@ public class ProcessFormsValuesProcessor extends KieWorkbenchFormsValuesProcesso
     }
 
     private ModelProperty generateModelProperty(String name, String type, ProcessRenderingSettings settings) {
+        Map<String, String[]> tags = settings.getProcessVariableTags();
+        if(tags != null) {
+            boolean required = Arrays.stream(tags.get(name)).anyMatch(tag -> tag.equals("required"));
+            boolean readonly = Arrays.stream(tags.get(name)).anyMatch(tag -> tag.equals("readonly"));
+            return BPMNVariableUtils.generateVariableProperty(name, type, required, readonly, settings.getMarshallerContext().getClassloader());
+        }
         return BPMNVariableUtils.generateVariableProperty(name, type, settings.getMarshallerContext().getClassloader());
     }
 

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/AbstractFormsValuesProcessorTest.java
@@ -168,6 +168,8 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
                                                                                true);
 
         checkGeneratedContext();
+        verifyProcessVariablesTags(renderingSettings,
+                                   kieWorkbenchFormRenderingSettings);
     }
 
     protected void checkGeneratedContext() {
@@ -292,4 +294,7 @@ public abstract class AbstractFormsValuesProcessorTest<PROCESSOR extends KieWork
     abstract PROCESSOR getProcessorInstance(FormDefinitionSerializer serializer,
                                             BackendFormRenderingContextManager backendFormRenderingContextManager,
                                             DynamicBPMNFormGenerator dynamicBPMNFormGenerator);
+
+    abstract void verifyProcessVariablesTags(SETTINGS renderingSettings,
+                                             KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings);
 }

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/ProcessFormsValuesProcessorTest.java
@@ -19,10 +19,12 @@ package org.jbpm.workbench.forms.display.backend.provider;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
 import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
 import org.jbpm.workbench.forms.display.backend.provider.util.FormContentReader;
 import org.jbpm.workbench.forms.service.providing.ProcessRenderingSettings;
 import org.jbpm.workbench.forms.service.providing.model.ProcessDefinition;
+import org.junit.Assert;
 import org.junit.runner.RunWith;
 import org.kie.workbench.common.forms.dynamic.service.context.generation.dynamic.BackendFormRenderingContextManager;
 import org.kie.workbench.common.forms.fields.test.TestMetaDataEntryManager;
@@ -61,6 +63,17 @@ public class ProcessFormsValuesProcessorTest extends AbstractFormsValuesProcesso
     }
 
     @Override
+    void verifyProcessVariablesTags(ProcessRenderingSettings renderingSettings,
+                                    KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings) {
+        Assert.assertTrue(kieWorkbenchFormRenderingSettings.getRenderingContext()
+                                  .getAvailableForms().get("invoices-taskform")
+                                  .getFieldByName("invoice").getRequired());
+        Assert.assertTrue(kieWorkbenchFormRenderingSettings.getRenderingContext()
+                                  .getAvailableForms().get("invoices-taskform")
+                                  .getFieldByName("invoice").getReadOnly());
+    }
+
+    @Override
     ProcessRenderingSettings getFullRenderingSettings() {
         return getRenderSettings(FormContentReader.getStartProcessForms());
     }
@@ -72,12 +85,16 @@ public class ProcessFormsValuesProcessorTest extends AbstractFormsValuesProcesso
 
     private ProcessRenderingSettings getRenderSettings(String formContent) {
         Map<String, String> formData = new HashMap<>();
+        Map<String, String[]> processVariableTags = new HashMap<>();
 
         formData.put("invoice",
                      Invoice.class.getName());
+        processVariableTags.put("invoice",
+                                new String[]{"required", "readonly"});
 
         return new ProcessRenderingSettings(process,
                                             formData,
+                                            processVariableTags,
                                             SERVER_TEMPLATE_ID,
                                             formContent,
                                             marshallerContext);

--- a/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
+++ b/jbpm-wb-forms/jbpm-wb-forms-backend/src/test/java/org/jbpm/workbench/forms/display/backend/provider/TaskFormValuesProcessorTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.jbpm.workbench.forms.display.api.KieWorkbenchFormRenderingSettings;
 import org.jbpm.workbench.forms.display.backend.provider.model.Client;
 import org.jbpm.workbench.forms.display.backend.provider.model.Invoice;
 import org.jbpm.workbench.forms.display.backend.provider.model.InvoiceLine;
@@ -107,5 +108,11 @@ public class TaskFormValuesProcessorTest extends AbstractFormsValuesProcessorTes
         return new TaskFormValuesProcessor(serializer,
                                            backendFormRenderingContextManager,
                                            dynamicBPMNFormGenerator);
+    }
+
+    @Override
+    void verifyProcessVariablesTags(TaskRenderingSettings renderingSettings,
+                                    KieWorkbenchFormRenderingSettings kieWorkbenchFormRenderingSettings) {
+
     }
 }


### PR DESCRIPTION
* Added tags to Display settings

**JIRA**: 
[AF-2811](https://issues.redhat.com/browse/AF-2811)
[RHPAM-3047](https://issues.redhat.com/browse/RHPAM-3047)

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
