### PR TITLE
KOGITO-5016: Remove Kogito-related modules from v7 stream

### DIFF
--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -1461,13 +1461,6 @@
       <scope>runtime</scope>
     </dependency>
 
-    <!-- TODO kogito needs refactoring out of jBPM-WB -->
-    <dependency>
-      <groupId>org.kie.workbench</groupId>
-      <artifactId>kie-wb-common-kogito-client</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
     <!-- Stunner and BPMN set. -->
     <dependency>
       <groupId>org.kie.workbench.stunner</groupId>
@@ -1928,9 +1921,6 @@
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-jbpm-designer-integration-shared</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-jbpm-designer-integration-api</compileSourcesArtifact>
             <compileSourcesArtifact>org.kie.workbench.stunner:kie-wb-common-stunner-jbpm-designer-integration-client</compileSourcesArtifact>
-
-            <!-- TODO kogito needs refactoring out of jBPM-WB -->
-            <compileSourcesArtifact>org.kie.workbench:kie-wb-common-kogito-client</compileSourcesArtifact>
 
             <!-- Dashbuilder -->
             <compileSourcesArtifact>org.kie.soup:kie-soup-json</compileSourcesArtifact>


### PR DESCRIPTION
**Thank you for submitting this pull request**

**JIRA**: [KOGITO-5016](https://issues.redhat.com/browse/KOGITO-5016)

**Parent Pull Request**:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1637

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
