### PR TITLE
[7.67.x-blue] BAPL-2291 Remove PLANNING capability

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerIntegration.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerIntegration.java
@@ -388,9 +388,6 @@ public class KieServerIntegration {
             if (serverTemplate.getCapabilities().contains(Capability.RULE.name())) {
                 mappedCapabilities.add(KieServerConstants.CAPABILITY_BRM);
             }
-            if (serverTemplate.getCapabilities().contains(Capability.PLANNING.name())) {
-                mappedCapabilities.add(KieServerConstants.CAPABILITY_BRP);
-            }
 
             final KieServicesClient kieServicesClient = createKieServicesClient(endpoints.toString(),
                                                                                 classLoader,


### PR DESCRIPTION
### JIRA

https://issues.redhat.com/browse/BAPL-2291

### Referenced Pull Requests
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1975
- https://github.com/kiegroup/droolsjbpm-integration/pull/2786
- https://github.com/kiegroup/kie-wb-playground/pull/129
- https://github.com/kiegroup/kie-wb-common/pull/3740
- https://github.com/kiegroup/jbpm-wb/pull/1547
- https://github.com/kiegroup/kie-wb-distributions/pull/1163

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
