### PR TITLE
[7.67.x-blue]JBPM-10111 Make the kieservice client timeout value configurable for …

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-api/src/main/java/org/jbpm/workbench/ks/utils/KieServerUtils.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-api/src/main/java/org/jbpm/workbench/ks/utils/KieServerUtils.java
@@ -44,7 +44,8 @@ public class KieServerUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(KieServerUtils.class);
 
     private static boolean KIE_SERVER_FORM_RENDERER = Boolean.parseBoolean(System.getProperty("org.jbpm.wb.forms.renderer.ext", "false"));
-    
+    private static Long KIE_SERVER_CLIENT_TIMEOUT = Long.parseLong(System.getProperty("org.jbpm.wb.kie.server.client.timeout", "60000"));
+
     public static KieServicesClient createKieServicesClient(final String... capabilities) {
         final String kieServerEndpoint = System.getProperty(KieServerConstants.KIE_SERVER_LOCATION);
         checkNotNull(kieServerEndpoint,
@@ -97,7 +98,7 @@ public class KieServerUtils {
                                                             final String... capabilities) {
         LOGGER.debug("Creating client that will use following endpoint {}",
                      endpoint);
-        configuration.setTimeout(60000);
+        configuration.setTimeout(KIE_SERVER_CLIENT_TIMEOUT);
         if (capabilities != null) {
             configuration.setCapabilities(Arrays.asList(capabilities));
         }


### PR DESCRIPTION
…Business central runtime capabilties

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[https://issues.redhat.com/browse/JBPM-10111](https://issues.redhat.com/browse/JBPM-10111)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
