### PR TITLE
[7.67.x-blue] [BXMSPROD-1845] elasticsearch removed from appformer

### DIFF
--- a/jbpm-wb-showcase/pom.xml
+++ b/jbpm-wb-showcase/pom.xml
@@ -561,12 +561,6 @@
 
     <dependency>
       <groupId>org.uberfire</groupId>
-      <artifactId>uberfire-metadata-backend-elasticsearch</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.uberfire</groupId>
       <artifactId>uberfire-metadata-backend-infinispan</artifactId>
       <scope>runtime</scope>
     </dependency>


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1845

Related PRs:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2102
* https://github.com/kiegroup/appformer/pull/1317
* https://github.com/kiegroup/kie-wb-common/pull/3782
* https://github.com/kiegroup/drools-wb/pull/1560
* https://github.com/kiegroup/jbpm-wb/pull/1574
* https://github.com/kiegroup/kie-wb-distributions/pull/1198
* https://github.com/kiegroup/optaplanner-wb/pull/415