### PR TITLE
RHPAM-4664: Date filter is not working as expected

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/DateColumnFilterFactory.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/DateColumnFilterFactory.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.ks.integration;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
+import org.dashbuilder.dataset.filter.ColumnFilter;
+import org.dashbuilder.dataset.filter.FilterFactory;
+import org.dashbuilder.dataset.group.ColumnGroup;
+import org.dashbuilder.dataset.group.DateIntervalType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Produces filter for date intervals
+ *
+ */
+public class DateColumnFilterFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DateColumnFilterFactory.class);
+
+    private static final DateTimeFormatter OUTPUT_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy[-MM][-dd][ HH][:mm][:ss]")
+            .parseDefaulting(ChronoField.YEAR_OF_ERA, 0)
+            .parseDefaulting(ChronoField.MONTH_OF_YEAR, 1)
+            .parseDefaulting(ChronoField.DAY_OF_MONTH, 1)
+            .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
+            .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
+            .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)
+            .toFormatter()
+            .withLocale(Locale.getDefault())
+            .withZone(ZoneId.from(ZoneOffset.UTC));
+
+    private DateColumnFilterFactory() {
+        // empty
+    }
+
+    @SuppressWarnings("unchecked")
+    public static ColumnFilter createFilter(ColumnGroup cg, @SuppressWarnings("rawtypes") List<Comparable> names) {
+        DateIntervalType intervalSize = DateIntervalType.getByName(cg.getIntervalSize());
+        ColumnFilter defaultFilter = FilterFactory.equalsTo(cg.getSourceId(), names);
+        Collections.sort(names);
+        if (names != null && !names.isEmpty() && intervalSize != null) {
+            String v1 = names.get(0).toString();
+            String v2 = names.get(names.size() - 1).toString();
+            LocalDateTime i = LocalDateTime.parse(v1, OUTPUT_FORMATTER);
+            LocalDateTime ii = LocalDateTime.parse(v2, OUTPUT_FORMATTER);
+            if (v1.equals(v2) || intervalSize != DateIntervalType.SECOND) {
+                ii = advanceUnit(intervalSize, ii);
+            }
+            try {
+                return FilterFactory.between(cg.getSourceId(), OUTPUT_FORMATTER.format(i), OUTPUT_FORMATTER.format(ii));
+            } catch (Exception e) {
+                LOGGER.info("Not able to parse dates for names {} and interval {}.", names, intervalSize);
+                LOGGER.debug("Error parsing dates while building request to Kie Server.", e);
+            }
+        }
+        return defaultFilter;
+    }
+
+    private static LocalDateTime advanceUnit(DateIntervalType intervalSize, LocalDateTime ii) {
+        switch (intervalSize) {
+            case DAY:
+            case WEEK:
+            case DAY_OF_WEEK:
+                return ii.plus(1l, ChronoUnit.DAYS);
+            case HOUR:
+                return ii.plus(1l, ChronoUnit.HOURS);
+            case MINUTE:
+                return ii.plus(1l, ChronoUnit.MINUTES);
+            case SECOND:
+                return ii.plus(1l, ChronoUnit.SECONDS);
+            case MONTH:
+            case QUARTER:
+                return ii.plus(1l, ChronoUnit.MONTHS);
+            case YEAR:
+                return ii.plus(1l, ChronoUnit.YEARS);
+            default:
+                return ii;
+
+        }
+
+    }
+
+}

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerDataSetProvider.java
@@ -75,7 +75,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
 
         if (def.getColumns() == null && def instanceof RemoteDataSetDef) {
             final QueryServicesClient queryClient = getClient(((RemoteDataSetDef) def).getServerTemplateId(),
-                                                              QueryServicesClient.class);
+                    QueryServicesClient.class);
 
             QueryDefinition definition = queryClient.getQuery(def.getUUID());
             if (definition != null) {
@@ -88,12 +88,12 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
             columnTypes.add(column.getColumnType());
         }
         return new DataSetMetadataImpl(def,
-                                       def.getUUID(),
-                                       -1,
-                                       def.getColumns().size(),
-                                       columnNames,
-                                       columnTypes,
-                                       -1);
+                def.getUUID(),
+                -1,
+                def.getColumns().size(),
+                columnNames,
+                columnTypes,
+                -1);
     }
 
     @Override
@@ -101,18 +101,18 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                                  DataSetLookup lookup) throws Exception {
 
         ConsoleDataSetLookup dataSetLookup = adoptLookup(def,
-                                                         lookup);
+                lookup);
 
         LOGGER.debug("Data Set lookup using Server Template Id: {}",
-                     dataSetLookup.getServerTemplateId());
+                dataSetLookup.getServerTemplateId());
         if (dataSetLookup.getServerTemplateId() == null || dataSetLookup.getServerTemplateId().isEmpty()) {
             return buildDataSet(def,
-                                new ArrayList<>(),
-                                new ArrayList<>());
+                    new ArrayList<>(),
+                    new ArrayList<>());
         }
 
         final QueryServicesClient queryClient = getClient(dataSetLookup.getServerTemplateId(),
-                                                          QueryServicesClient.class);
+                QueryServicesClient.class);
 
         List<QueryParam> filterParams = new ArrayList<>();
         QueryFilterSpec filterSpec = new QueryFilterSpec();
@@ -127,13 +127,13 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                         CoreFunctionFilter coreFunctionFilter = (CoreFunctionFilter) cFilter;
 
                         filterParams.add(new QueryParam(coreFunctionFilter.getColumnId(),
-                                                        coreFunctionFilter.getType().toString(),
-                                                        coreFunctionFilter.getParameters()));
+                                coreFunctionFilter.getType().toString(),
+                                coreFunctionFilter.getParameters()));
                     } else if (cFilter instanceof LogicalExprFilter) {
                         LogicalExprFilter logicalExprFilter = (LogicalExprFilter) cFilter;
                         filterParams.add(new QueryParam(logicalExprFilter.getColumnId(),
-                                                        logicalExprFilter.getLogicalOperator().toString(),
-                                                        logicalExprFilter.getLogicalTerms()));
+                                logicalExprFilter.getLogicalOperator().toString(),
+                                logicalExprFilter.getLogicalTerms()));
                     }
                 }
             }
@@ -143,16 +143,17 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
         List<DataSetGroup> dataSetGroups = lookup.getFirstGroupOpSelections();
         for (DataSetGroup group : dataSetGroups) {
             if (group.getSelectedIntervalList() != null && group.getSelectedIntervalList().size() > 0) {
-                appendIntervalSelection(group,
-                                        filterParams);
+                appendIntervalSelection(def,
+                        group,
+                        filterParams);
             }
         }
 
         DataSetGroup dataSetGroup = dataSetLookup.getLastGroupOp();
         handleDataSetGroup(def,
-                           dataSetGroup,
-                           filterParams,
-                           extraColumns);
+                dataSetGroup,
+                filterParams,
+                extraColumns);
 
         if (!filterParams.isEmpty()) {
             filterSpec.setParameters(filterParams.toArray(new QueryParam[filterParams.size()]));
@@ -174,15 +175,15 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
             filterSpec.setAscending(sortOrder.equals(SortOrder.ASCENDING));
         }
         final List<List> instances = performQuery((RemoteDataSetDef) def,
-                                                  dataSetLookup,
-                                                  queryClient,
-                                                  filterSpec);
+                dataSetLookup,
+                queryClient,
+                filterSpec);
         LOGGER.debug("Query client returned {} row(s)",
-                     instances.size());
+                instances.size());
 
         return buildDataSet(def,
-                            instances,
-                            extraColumns);
+                instances,
+                extraColumns);
     }
 
     protected ConsoleDataSetLookup adoptLookup(DataSetDef def,
@@ -192,7 +193,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
 
             if (def instanceof RemoteDataSetDef) {
                 dataSetLookup = (ConsoleDataSetLookup) ConsoleDataSetLookup.fromInstance(lookup,
-                                                                                         ((RemoteDataSetDef) def).getServerTemplateId());
+                        ((RemoteDataSetDef) def).getServerTemplateId());
                 DataSetFilter filter = def.getDataSetFilter();
                 if (filter != null) {
                     dataSetLookup.addOperation(filter);
@@ -222,20 +223,20 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                     .build();
 
             kieServerIntegration.broadcastToKieServers(((RemoteDataSetDef) def).getServerTemplateId(),
-                                                       (KieServicesClient client) -> {
-                                                           QueryServicesClient instanceQueryClient = client.getServicesClient(QueryServicesClient.class);
-                                                           QueryDefinition registered = instanceQueryClient.replaceQuery(queryDefinition);
-                                                           if (registered.getColumns() != null) {
+                    (KieServicesClient client) -> {
+                        QueryServicesClient instanceQueryClient = client.getServicesClient(QueryServicesClient.class);
+                        QueryDefinition registered = instanceQueryClient.replaceQuery(queryDefinition);
+                        if (registered.getColumns() != null) {
 
-                                                               for (Entry<String, String> entry : registered.getColumns().entrySet()) {
-                                                                   if (def.getColumnById(entry.getKey()) == null) {
-                                                                       def.addColumn(entry.getKey(),
-                                                                                     ColumnType.valueOf(entry.getValue()));
-                                                                   }
-                                                               }
-                                                           }
-                                                           return registered;
-                                                       });
+                            for (Entry<String, String> entry : registered.getColumns().entrySet()) {
+                                if (def.getColumnById(entry.getKey()) == null) {
+                                    def.addColumn(entry.getKey(),
+                                            ColumnType.valueOf(entry.getValue()));
+                                }
+                            }
+                        }
+                        return registered;
+                    });
 
             try {
                 return queryClient.query(
@@ -244,8 +245,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                         filterSpec,
                         dataSetLookup.getRowOffset() / dataSetLookup.getNumberOfRows(),
                         dataSetLookup.getNumberOfRows(),
-                        List.class
-                );
+                        List.class);
             } catch (Exception e) {
                 queryClient.unregisterQuery(dataSetLookup.getDataSetUUID());
                 throw new RuntimeException(e);
@@ -263,8 +263,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                     filterSpec,
                     dataSetLookup.getRowOffset() / dataSetLookup.getNumberOfRows(),
                     dataSetLookup.getNumberOfRows(),
-                    List.class
-            );
+                    List.class);
         }
     }
 
@@ -289,7 +288,7 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
 
             for (DataColumnDef column : def.getColumns()) {
                 DataColumn numRows = new DataColumnImpl(column.getId(),
-                                                        column.getColumnType());
+                        column.getColumnType());
                 dataSet.addColumn(numRows);
             }
         }
@@ -300,7 +299,8 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
             for (Object value : row) {
                 DataColumn intervalBuilder = dataSet.getColumnByIndex(columnIndex);
                 if (intervalBuilder.getColumnType().equals(ColumnType.DATE) && value instanceof Long) {
-                    intervalBuilder.getValues().add(new Date((Long)value));
+                    intervalBuilder.getValues().add(new Date((Long) value));
+
                 } else {
                     intervalBuilder.getValues().add(value);
                 }
@@ -309,67 +309,72 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
             }
         }
         // set size of the results to allow paging to be more then the actual size
-//        dataSet.setRowCountNonTrimmed(instances.size() == 0 ? 0 : instances.size() + 1);
+        //        dataSet.setRowCountNonTrimmed(instances.size() == 0 ? 0 : instances.size() + 1);
         dataSet.setRowCountNonTrimmed(instances.size());
         return dataSet;
     }
 
-    protected void appendIntervalSelection(DataSetGroup intervalSel,
+    protected void appendIntervalSelection(DataSetDef def,
+                                           DataSetGroup intervalSel,
                                            List<QueryParam> filterParams) {
-        if (intervalSel != null && intervalSel.isSelect()) {
-            ColumnGroup cg = intervalSel.getColumnGroup();
-            List<Interval> intervalList = intervalSel.getSelectedIntervalList();
-
-            // Get the filter values
-            List<Comparable> names = new ArrayList<Comparable>();
-            Comparable min = null;
-            Comparable max = null;
-            for (Interval interval : intervalList) {
-                names.add(interval.getName());
-                Comparable intervalMin = (Comparable) interval.getMinValue();
-                Comparable intervalMax = (Comparable) interval.getMaxValue();
-
-                if (intervalMin != null) {
-                    if (min == null) {
-                        min = intervalMin;
-                    } else if (min.compareTo(intervalMin) > 0) {
-                        min = intervalMin;
-                    }
-                }
-                if (intervalMax != null) {
-                    if (max == null) {
-                        max = intervalMax;
-                    } else if (max.compareTo(intervalMax) > 0) {
-                        max = intervalMax;
-                    }
-                }
-            }
-            // Min can't be greater than max.
-            if (min != null && max != null && min.compareTo(max) > 0) {
-                min = max;
-            }
-
-            ColumnFilter filter;
-            if (min != null && max != null) {
-                filter = FilterFactory.between(cg.getSourceId(),
-                                               min,
-                                               max);
-            } else if (min != null) {
-                filter = FilterFactory.greaterOrEqualsTo(cg.getSourceId(),
-                                                         min);
-            } else if (max != null) {
-                filter = FilterFactory.lowerOrEqualsTo(cg.getSourceId(),
-                                                       max);
-            } else {
-                filter = FilterFactory.equalsTo(cg.getSourceId(),
-                                                names);
-            }
-
-            CoreFunctionFilter coreFunctionFilter = (CoreFunctionFilter) filter;
-            filterParams.add(new QueryParam(coreFunctionFilter.getColumnId(),
-                                            coreFunctionFilter.getType().toString(),
-                                            coreFunctionFilter.getParameters()));
+        if (intervalSel == null || !intervalSel.isSelect()) {
+            return;
         }
+        ColumnGroup cg = intervalSel.getColumnGroup();
+        List<Interval> intervalList = intervalSel.getSelectedIntervalList();
+        DataColumnDef columnDef = def.getColumnById(cg.getSourceId());
+
+        // Get the filter values
+        List<Comparable> names = new ArrayList<Comparable>();
+        Comparable min = null;
+        Comparable max = null;
+        for (Interval interval : intervalList) {
+            names.add(interval.getName());
+            Comparable intervalMin = (Comparable) interval.getMinValue();
+            Comparable intervalMax = (Comparable) interval.getMaxValue();
+
+            if (intervalMin != null) {
+                if (min == null) {
+                    min = intervalMin;
+                } else if (min.compareTo(intervalMin) > 0) {
+                    min = intervalMin;
+                }
+            }
+            if (intervalMax != null) {
+                if (max == null) {
+                    max = intervalMax;
+                } else if (max.compareTo(intervalMax) > 0) {
+                    max = intervalMax;
+                }
+            }
+        }
+        // Min can't be greater than max.
+        if (min != null && max != null && min.compareTo(max) > 0) {
+            min = max;
+        }
+
+        ColumnFilter filter;
+        if (min != null && max != null) {
+            filter = FilterFactory.between(cg.getSourceId(),
+                    min,
+                    max);
+        } else if (min != null) {
+            filter = FilterFactory.greaterOrEqualsTo(cg.getSourceId(),
+                    min);
+        } else if (max != null) {
+            filter = FilterFactory.lowerOrEqualsTo(cg.getSourceId(),
+                    max);
+        } else if (columnDef != null && columnDef.getColumnType() == ColumnType.DATE) {
+            filter = DateColumnFilterFactory.createFilter(cg, names);
+        } else {
+            filter = FilterFactory.equalsTo(cg.getSourceId(),
+                    names);
+        }
+        CoreFunctionFilter coreFunctionFilter = (CoreFunctionFilter) filter;
+        filterParams.add(new QueryParam(coreFunctionFilter.getColumnId(),
+                coreFunctionFilter.getType().toString(),
+                coreFunctionFilter.getParameters()));
+
     }
 
     protected void handleDataSetGroup(final DataSetDef def,
@@ -381,14 +386,14 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
                 // handle group
                 if (dataSetGroup.getColumnGroup().getIntervalSize() != null) {
                     filterParams.add(new QueryParam(dataSetGroup.getColumnGroup().getSourceId(),
-                                                    "group",
-                                                    Arrays.asList(dataSetGroup.getColumnGroup().getColumnId(),
-                                                                  dataSetGroup.getColumnGroup().getIntervalSize(),
-                                                                  dataSetGroup.getColumnGroup().getMaxIntervals())));
+                            "group",
+                            Arrays.asList(dataSetGroup.getColumnGroup().getColumnId(),
+                                    dataSetGroup.getColumnGroup().getIntervalSize(),
+                                    dataSetGroup.getColumnGroup().getMaxIntervals())));
                 } else {
                     filterParams.add(new QueryParam(dataSetGroup.getColumnGroup().getSourceId(),
-                                                    "group",
-                                                    Arrays.asList(dataSetGroup.getColumnGroup().getColumnId())));
+                            "group",
+                            Arrays.asList(dataSetGroup.getColumnGroup().getColumnId())));
                 }
             }
 
@@ -396,18 +401,18 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
             for (GroupFunction groupFunction : dataSetGroup.getGroupFunctions()) {
                 if (groupFunction.getFunction() != null) {
                     filterParams.add(new QueryParam(groupFunction.getSourceId(),
-                                                    groupFunction.getFunction().toString(),
-                                                    Arrays.asList(groupFunction.getColumnId())));
+                            groupFunction.getFunction().toString(),
+                            Arrays.asList(groupFunction.getColumnId())));
                     extraColumns.add(new DataColumnImpl(groupFunction.getSourceId(),
-                                                        ColumnType.NUMBER));
+                            ColumnType.NUMBER));
                 } else {
                     filterParams.add(new QueryParam(groupFunction.getSourceId(),
-                                                    null,
-                                                    Arrays.asList(groupFunction.getColumnId())));
+                            null,
+                            Arrays.asList(groupFunction.getColumnId())));
                     extraColumns.add(new DataColumnImpl(groupFunction.getSourceId(),
-                                                        getGroupFunctionColumnType(def,
-                                                                                   dataSetGroup.getColumnGroup(),
-                                                                                   groupFunction)));
+                            getGroupFunctionColumnType(def,
+                                    dataSetGroup.getColumnGroup(),
+                                    groupFunction)));
                 }
             }
         }
@@ -416,24 +421,24 @@ public class KieServerDataSetProvider extends AbstractKieServerService implement
     protected ColumnType getGroupFunctionColumnType(final DataSetDef def,
                                                     final ColumnGroup columnGroup,
                                                     final GroupFunction groupFunction) {
-        
+
         DataColumnDef column = def.getColumnById(groupFunction.getColumnId());
         if (column == null) {
             column = def.getColumnById(groupFunction.getSourceId());
         }
         ColumnType type = column.getColumnType();
-        if(type != ColumnType.DATE || columnGroup == null || groupFunction == null){
+        if (type != ColumnType.DATE || columnGroup == null || groupFunction == null) {
             return type;
         } else {
             return columnGroup.getSourceId().equals(groupFunction.getSourceId()) ? ColumnType.LABEL : type;
         }
     }
-    
+
     protected void addColumnsToDefinition(DataSetDef def, Map<String, String> columns) {
         if (columns != null) {
             columns.entrySet().stream()
-                   .filter(e -> def.getColumnById(e.getKey()) == null)
-                   .forEach(e -> def.addColumn(e.getKey(), ColumnType.valueOf(e.getValue())));
+                    .filter(e -> def.getColumnById(e.getKey()) == null)
+                    .forEach(e -> def.addColumn(e.getKey(), ColumnType.valueOf(e.getValue())));
         }
     }
 }

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/DateColumnFilterFactoryTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/DateColumnFilterFactoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.ks.integration;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+
+import org.dashbuilder.dataset.filter.CoreFunctionFilter;
+import org.dashbuilder.dataset.group.ColumnGroup;
+import org.dashbuilder.dataset.group.DateIntervalType;
+import org.junit.Before;
+import org.junit.Test;
+
+public class DateColumnFilterFactoryTest {
+
+    private ColumnGroup cg;
+
+    @Before
+    public void prepare() {
+        cg = new ColumnGroup("test", "test");
+
+    }
+
+    @Test
+    public void testDateColumnFilterFactorySecond() {
+        cg.setIntervalSize(DateIntervalType.SECOND.name());
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10-01 01:01:01", "2023-11-02 02:02:02"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 01:01:01", filter.getParameters().get(0));
+        assertEquals("2023-11-02 02:02:02", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryMinute() {
+        cg.setIntervalSize(DateIntervalType.MINUTE.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10-01 01:01", "2023-11-02 02:02"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 01:01:00", filter.getParameters().get(0));
+        assertEquals("2023-11-02 02:03:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryHour() {
+        cg.setIntervalSize(DateIntervalType.HOUR.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10-01 01", "2023-11-02 02"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 01:00:00", filter.getParameters().get(0));
+        assertEquals("2023-11-02 03:00:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryDay() {
+        cg.setIntervalSize(DateIntervalType.DAY.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10-01", "2023-11-02"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 00:00:00", filter.getParameters().get(0));
+        assertEquals("2023-11-03 00:00:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryDayOrder() {
+        cg.setIntervalSize(DateIntervalType.DAY.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-11-02", "2023-10-01"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 00:00:00", filter.getParameters().get(0));
+        assertEquals("2023-11-03 00:00:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryDayEqualsValue() {
+        cg.setIntervalSize(DateIntervalType.DAY.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10-01", "2023-10-01"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 00:00:00", filter.getParameters().get(0));
+        assertEquals("2023-10-02 00:00:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryMonth() {
+        cg.setIntervalSize(DateIntervalType.MONTH.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023-10", "2023-11"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-10-01 00:00:00", filter.getParameters().get(0));
+        assertEquals("2023-12-01 00:00:00", filter.getParameters().get(1));
+    }
+
+    @Test
+    public void testDateColumnFilterFactoryYear() {
+        cg.setIntervalSize(DateIntervalType.YEAR.name());
+
+        CoreFunctionFilter filter = (CoreFunctionFilter) DateColumnFilterFactory.createFilter(cg, Arrays.asList(
+                "2023", "2024"));
+        assertEquals("test", filter.getColumnId());
+        assertEquals("2023-01-01 00:00:00", filter.getParameters().get(0));
+        assertEquals("2025-01-01 00:00:00", filter.getParameters().get(1));
+    }
+
+}

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerDataSetProviderTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerDataSetProviderTest.java
@@ -104,7 +104,9 @@ public class KieServerDataSetProviderTest {
         dataSetGroup.setSelectedIntervalList(intervalList);
 
         List<QueryParam> filterParams = new ArrayList<>();
-        kieServerDataSetProvider.appendIntervalSelection(dataSetGroup,
+        
+        kieServerDataSetProvider.appendIntervalSelection(dataSetDef,
+                                                         dataSetGroup,
                                                          filterParams);
 
         assertEquals(1,
@@ -135,7 +137,8 @@ public class KieServerDataSetProviderTest {
         dataSetGroup.setSelectedIntervalList(intervalList);
         List<QueryParam> filterParams = new ArrayList<>();
 
-        kieServerDataSetProvider.appendIntervalSelection(dataSetGroup,
+        kieServerDataSetProvider.appendIntervalSelection(dataSetDef,
+                dataSetGroup,
                                                          filterParams);
 
         assertEquals(1,


### PR DESCRIPTION
[JBPM-10167](https://issues.redhat.com/browse/JBPM-10167)

*Date filter is not working as expected*

In remote datasets the date filter is generate as an `COLUMN = {value selected by user}`. It does not work for dates. With this change we generate a BETWEEN operator for dates only and a suitable interval of dates so the correct values are generated.