### PR TITLE
[private-bamoe-issues #1456] Fix query definitions to enforce filtering for jbpmProcessInstances, jbpmProcessInstancesWithVariables, taskMonitoring queries

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions.json
@@ -3,7 +3,7 @@
     "query-name": "jbpmProcessInstances",
     "query-source": "${org.kie.server.persistence.ds}",
     "query-expression": "SELECT LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE ) AS LASTMODIFICATIONDATE, COUNT( ERRINFO.ID ) ERRORCOUNT FROM ProcessInstanceLog LOG LEFT JOIN ExecutionErrorInfo ERRINFO ON ERRINFO.PROCESS_INST_ID=LOG.PROCESSINSTANCEID AND ERRINFO.ERROR_ACK=0 LEFT JOIN ProcessInstanceInfo INFO ON INFO.INSTANCEID=LOG.PROCESSINSTANCEID GROUP BY LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE )",
-    "query-target": "CUSTOM"
+    "query-target": "FILTERED_PROCESS"
   },
   {
     "query-name": "jbpmProcessInstancesWithVariables",
@@ -15,13 +15,13 @@
     "query-name": "processesMonitoring",
     "query-source": "${org.kie.server.persistence.ds}",
     "query-expression": "select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, log.duration, log.user_identity, log.processVersion, log.processName, log.externalId from ProcessInstanceLog log",
-    "query-target": "CUSTOM"
+    "query-target": "FILTERED_PROCESS"
   },
   {
     "query-name": "tasksMonitoring",
     "query-source": "${org.kie.server.persistence.ds}",
     "query-expression": "select p.processName, p.externalId, t.taskId, t.taskName, t.status, t.createdDate, t.startDate, t.endDate, t.processInstanceId, t.userId, t.duration from ProcessInstanceLog p inner join BAMTaskSummary t on (t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk from BAMTaskSummary group by taskId) d on t.pk = d.pk",
-    "query-target": "CUSTOM"
+    "query-target": "FILTERED_PROCESS"
   },
   {
     "query-name": "jbpmRequestList",


### PR DESCRIPTION
Changing the query-target to match the query definitions in [kie-server tests](https://github.com/kiegroup/droolsjbpm-integration/blob/main/kie-server-parent/kie-server-services/kie-server-services-jbpm/src/test/resources/default-query-definitions.json)