### PR TITLE
RHPAM-4889: using a feature flag to enable/disable strict mode.

### DIFF
--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoader.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoader.java
@@ -19,6 +19,8 @@ package org.jbpm.workbench.ks.integration;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
@@ -69,53 +71,50 @@ public class KieServerQueryDefinitionLoader {
     }
 
     protected void loadDefaultQueryDefinitions(final QueryMode queryMode) {
-        final String resourceName;
+        final Map<String, String> applyStrict = new HashMap<>();
 
-        if (QueryMode.STRICT.equals(queryMode)){
-            resourceName = "/default-query-definitions-strict.json";
-        } else {
-            resourceName = "/default-query-definitions.json";
+        if (QueryMode.STRICT.equals(queryMode)) {
+            QueryDefinition[] queries = loadQueryDefinitions("/default-query-definitions-strict.json");
+            for (QueryDefinition q : queries) {
+                applyStrict.put(q.getName(), q.getTarget());
+            }
         }
 
-        // load any default query definitions
-        try (InputStream qdStream = this.getClass().getResourceAsStream(resourceName)) {
-            if (qdStream == null) {
-                LOGGER.info("Default query definitions file " + resourceName + " not found");
-                return;
+        final QueryDefinition[] queries = loadQueryDefinitions("/default-query-definitions.json");
+        for (QueryDefinition q : queries) {
+            if (applyStrict.containsKey(q.getName())){
+                q.setTarget(applyStrict.get(q.getName()));
             }
-            loadQueryDefinitions(qdStream,
-                                 MarshallerFactory.getMarshaller(MarshallingFormat.JSON,
-                                                                 this.getClass().getClassLoader()));
-        } catch (Exception e) {
-            LOGGER.error("Error when loading default query definitions from " + resourceName,
-                         e);
+            LOGGER.info("Loaded query definition: {}", q);
+            event.fire(new QueryDefinitionLoaded(q));
         }
     }
 
-    protected void loadQueryDefinitions(final InputStream qdStream,
-                                        final Marshaller marshaller) throws IOException {
-        final String qdString = IOUtils.toString(qdStream,
-                                                 Charset.forName("UTF-8"));
+    protected QueryDefinition[] loadQueryDefinitions(String resourceName) {
 
-        try {
-            QueryDefinition[] queries = marshaller.unmarshall(qdString,
-                                                              QueryDefinition[].class);
-
-            LOGGER.info("Found {} query definitions",
-                        queries == null ? 0 : queries.length);
-
-            if (queries == null) {
-                return;
+        try (InputStream qdStream = this.getClass().getResourceAsStream(resourceName)) {
+            if (qdStream == null) {
+                LOGGER.info("Default query definitions file " + resourceName + " not found");
+                return new QueryDefinition[0];
             }
-            for (QueryDefinition q :
-                    queries) {
-                LOGGER.info("Loaded query definition: {}",
-                            q);
-                event.fire(new QueryDefinitionLoaded(q));
+
+            final String qdString = IOUtils.toString(qdStream, Charset.forName("UTF-8"));
+
+            QueryDefinition[] queries = MarshallerFactory.getMarshaller(MarshallingFormat.JSON, this.getClass().getClassLoader()).unmarshall(qdString, QueryDefinition[].class);
+
+            LOGGER.info("Found {} query definitions", queries == null ? 0 : queries.length);
+
+            if (queries == null){
+                return new QueryDefinition[0];
             }
+
+            return queries;
         } catch (MarshallingException e) {
-            LOGGER.error("Error when unmarshalling query definitions from stream.",
-                         e);
+            LOGGER.error("Error when unmarshalling query definitions from stream.", e);
+        } catch (Exception e) {
+            LOGGER.error("Error when loading default query definitions from " + resourceName, e);
         }
+
+        return new QueryDefinition[0];
     }
 }

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions-strict.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions-strict.json
@@ -1,0 +1,74 @@
+[
+  {
+    "query-name": "jbpmProcessInstances",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "SELECT LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE ) AS LASTMODIFICATIONDATE, COUNT( ERRINFO.ID ) ERRORCOUNT FROM ProcessInstanceLog LOG LEFT JOIN ExecutionErrorInfo ERRINFO ON ERRINFO.PROCESS_INST_ID=LOG.PROCESSINSTANCEID AND ERRINFO.ERROR_ACK=0 LEFT JOIN ProcessInstanceInfo INFO ON INFO.INSTANCEID=LOG.PROCESSINSTANCEID GROUP BY LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE )",
+    "query-target": "FILTERED_PROCESS"
+  },
+  {
+    "query-name": "jbpmProcessInstancesWithVariables",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select vil.processInstanceId, vil.processId, vil.id, vil.variableId, vil.value from VariableInstanceLog vil left join VariableInstanceLog vil2 on vil.processInstanceId = vil2.processInstanceId and vil.variableId = vil2.variableId and vil.id < vil2.id where vil2.id is null",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "processesMonitoring",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, log.duration, log.user_identity, log.processVersion, log.processName, log.externalId from ProcessInstanceLog log",
+    "query-target": "FILTERED_PROCESS"
+  },
+  {
+    "query-name": "tasksMonitoring",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select p.processName, p.externalId, t.taskId, t.taskName, t.status, t.createdDate, t.startDate, t.endDate, t.processInstanceId, t.userId, t.duration from ProcessInstanceLog p inner join BAMTaskSummary t on (t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk from BAMTaskSummary group by taskId) d on t.pk = d.pk",
+    "query-target": "FILTERED_PROCESS"
+  },
+  {
+    "query-name": "jbpmRequestList",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select ri.id, ri.timestamp, ri.status, ri.commandName, ri.message, ri.businessKey, ri.retries, ri.executions, pil.processName, pil.processInstanceId, pil.processInstanceDescription, ri.deploymentId from RequestInfo ri left join ProcessInstanceLog pil on pil.processInstanceId=ri.processInstanceId",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "jbpmExecutionErrorList",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select eri.ERROR_ACK, eri.ERROR_ACK_BY, eri.ERROR_ACK_AT, eri.ACTIVITY_ID, eri.ACTIVITY_NAME, eri.DEPLOYMENT_ID, eri.ERROR_DATE, eri.ERROR_ID, eri.ERROR_MSG, eri.JOB_ID, eri.PROCESS_ID, eri.PROCESS_INST_ID, eri.ERROR_TYPE from ExecutionErrorInfo eri",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "jbpmHumanTasks",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription, nil.sla_due_date, nil.slaCompliance from AuditTaskImpl t left join ProcessInstanceLog pil on pil.processInstanceId=t.processInstanceId left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "jbpmHumanTasksWithUser",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription , oe.id, eo.entity_id, nil.sla_due_date, nil.slaCompliance from AuditTaskImpl t left join PeopleAssignments_PotOwners po on t.taskId=po.task_id left join OrganizationalEntity oe on po.entity_id=oe.id left join ProcessInstanceLog pil on pil.processInstanceId=t.processInstanceId left join PeopleAssignments_ExclOwners eo on t.taskId=eo.task_id left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
+    "query-target": "FILTERED_PO_TASK"
+  },
+  {
+    "query-name": "jbpmHumanTasksWithAdmin",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription ,oe.id, nil.sla_due_date, nil.slaCompliance, (select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.ACTIVITY_ID = t.taskId and errInfo.PROCESS_INST_ID = pil.processInstanceId and errInfo.ERROR_ACK = 0 and errInfo.ERROR_TYPE = 'Task') as errorCount from AuditTaskImpl t  left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
+    "query-target": "FILTERED_BA_TASK"
+  },
+  {
+    "query-name": "jbpmHumanTasksWithAdminExtended",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription ,oe.id, nil.sla_due_date, nil.slaCompliance,(select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.ACTIVITY_ID = t.taskId and errInfo.PROCESS_INST_ID = pil.processInstanceId and errInfo.ERROR_ACK = 0 and errInfo.ERROR_TYPE = 'Task') as errorCount, i18n.text  as subject, i18n.language as language, task.formname as formname, (SELECT te1.userId FROM TaskEvent te1 LEFT JOIN TaskEvent te2 ON te1.id < te2.id WHERE te2.id IS NULL) as lastUser from AuditTaskImpl t  left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId left join Task task on task.id = t.taskId left join I18NText i18n ON i18n.Task_Subjects_Id = t.taskId",
+    "query-target": "FILTERED_BA_TASK"
+  },
+  {
+    "query-name": "jbpmHumanTasksWithVariables",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select tvi.taskId, tvi.name, tvi.value from TaskVariableImpl tvi",
+    "query-target": "CUSTOM"
+  },
+  {
+    "query-name": "jbpmProcessInstanceLogs",
+    "query-source": "${org.kie.server.persistence.ds}",
+    "query-expression": "select log.id, log.nodeId, log.nodeName, log.nodeType, log.externalId, log.processInstanceId, log.log_date, log.connection, log.type, log.workItemId, log.referenceId, log.nodeContainerId, log.sla_due_date, log.slaCompliance from NodeInstanceLog log ",
+    "query-target": "CUSTOM"
+  }
+]

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions-strict.json
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/main/resources/default-query-definitions-strict.json
@@ -1,74 +1,14 @@
 [
   {
     "query-name": "jbpmProcessInstances",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "SELECT LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE ) AS LASTMODIFICATIONDATE, COUNT( ERRINFO.ID ) ERRORCOUNT FROM ProcessInstanceLog LOG LEFT JOIN ExecutionErrorInfo ERRINFO ON ERRINFO.PROCESS_INST_ID=LOG.PROCESSINSTANCEID AND ERRINFO.ERROR_ACK=0 LEFT JOIN ProcessInstanceInfo INFO ON INFO.INSTANCEID=LOG.PROCESSINSTANCEID GROUP BY LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE )",
     "query-target": "FILTERED_PROCESS"
   },
   {
-    "query-name": "jbpmProcessInstancesWithVariables",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select vil.processInstanceId, vil.processId, vil.id, vil.variableId, vil.value from VariableInstanceLog vil left join VariableInstanceLog vil2 on vil.processInstanceId = vil2.processInstanceId and vil.variableId = vil2.variableId and vil.id < vil2.id where vil2.id is null",
-    "query-target": "CUSTOM"
-  },
-  {
     "query-name": "processesMonitoring",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, log.duration, log.user_identity, log.processVersion, log.processName, log.externalId from ProcessInstanceLog log",
     "query-target": "FILTERED_PROCESS"
   },
   {
     "query-name": "tasksMonitoring",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select p.processName, p.externalId, t.taskId, t.taskName, t.status, t.createdDate, t.startDate, t.endDate, t.processInstanceId, t.userId, t.duration from ProcessInstanceLog p inner join BAMTaskSummary t on (t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk from BAMTaskSummary group by taskId) d on t.pk = d.pk",
     "query-target": "FILTERED_PROCESS"
-  },
-  {
-    "query-name": "jbpmRequestList",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select ri.id, ri.timestamp, ri.status, ri.commandName, ri.message, ri.businessKey, ri.retries, ri.executions, pil.processName, pil.processInstanceId, pil.processInstanceDescription, ri.deploymentId from RequestInfo ri left join ProcessInstanceLog pil on pil.processInstanceId=ri.processInstanceId",
-    "query-target": "CUSTOM"
-  },
-  {
-    "query-name": "jbpmExecutionErrorList",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select eri.ERROR_ACK, eri.ERROR_ACK_BY, eri.ERROR_ACK_AT, eri.ACTIVITY_ID, eri.ACTIVITY_NAME, eri.DEPLOYMENT_ID, eri.ERROR_DATE, eri.ERROR_ID, eri.ERROR_MSG, eri.JOB_ID, eri.PROCESS_ID, eri.PROCESS_INST_ID, eri.ERROR_TYPE from ExecutionErrorInfo eri",
-    "query-target": "CUSTOM"
-  },
-  {
-    "query-name": "jbpmHumanTasks",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription, nil.sla_due_date, nil.slaCompliance from AuditTaskImpl t left join ProcessInstanceLog pil on pil.processInstanceId=t.processInstanceId left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
-    "query-target": "CUSTOM"
-  },
-  {
-    "query-name": "jbpmHumanTasksWithUser",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription , oe.id, eo.entity_id, nil.sla_due_date, nil.slaCompliance from AuditTaskImpl t left join PeopleAssignments_PotOwners po on t.taskId=po.task_id left join OrganizationalEntity oe on po.entity_id=oe.id left join ProcessInstanceLog pil on pil.processInstanceId=t.processInstanceId left join PeopleAssignments_ExclOwners eo on t.taskId=eo.task_id left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
-    "query-target": "FILTERED_PO_TASK"
-  },
-  {
-    "query-name": "jbpmHumanTasksWithAdmin",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription ,oe.id, nil.sla_due_date, nil.slaCompliance, (select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.ACTIVITY_ID = t.taskId and errInfo.PROCESS_INST_ID = pil.processInstanceId and errInfo.ERROR_ACK = 0 and errInfo.ERROR_TYPE = 'Task') as errorCount from AuditTaskImpl t  left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId",
-    "query-target": "FILTERED_BA_TASK"
-  },
-  {
-    "query-name": "jbpmHumanTasksWithAdminExtended",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select t.activationTime, t.actualOwner, t.createdBy, t.createdOn, t.deploymentId, t.description, t.dueDate, t.name, t.parentId, t.priority, t.processId, t.processInstanceId, t.processSessionId, t.status, t.taskId, t.workItemId, t.lastModificationDate, pil.correlationKey, pil.processInstanceDescription ,oe.id, nil.sla_due_date, nil.slaCompliance,(select COUNT(errInfo.id) from ExecutionErrorInfo errInfo where errInfo.ACTIVITY_ID = t.taskId and errInfo.PROCESS_INST_ID = pil.processInstanceId and errInfo.ERROR_ACK = 0 and errInfo.ERROR_TYPE = 'Task') as errorCount, i18n.text  as subject, i18n.language as language, task.formname as formname, (SELECT te1.userId FROM TaskEvent te1 LEFT JOIN TaskEvent te2 ON te1.id < te2.id WHERE te2.id IS NULL) as lastUser from AuditTaskImpl t  left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId left join Task task on task.id = t.taskId left join I18NText i18n ON i18n.Task_Subjects_Id = t.taskId",
-    "query-target": "FILTERED_BA_TASK"
-  },
-  {
-    "query-name": "jbpmHumanTasksWithVariables",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select tvi.taskId, tvi.name, tvi.value from TaskVariableImpl tvi",
-    "query-target": "CUSTOM"
-  },
-  {
-    "query-name": "jbpmProcessInstanceLogs",
-    "query-source": "${org.kie.server.persistence.ds}",
-    "query-expression": "select log.id, log.nodeId, log.nodeName, log.nodeType, log.externalId, log.processInstanceId, log.log_date, log.connection, log.type, log.workItemId, log.referenceId, log.nodeContainerId, log.sla_due_date, log.slaCompliance from NodeInstanceLog log ",
-    "query-target": "CUSTOM"
   }
 ]

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoaderStrictModeTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoaderStrictModeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jbpm.workbench.ks.integration;
+
+import org.jbpm.workbench.ks.integration.event.QueryDefinitionLoaded;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kie.server.api.model.definition.QueryDefinition;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.enterprise.event.Event;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.MockitoAnnotations.openMocks;
+
+/**
+ * This test class has been created to make contributors aware about the importance of the queries defined in the
+ * "default-query-definitions.json" file. These queries has been tested and optimized due to some important performance
+ * issues found on a very important and critical customer.
+ * Please, consider running a performance test when one of them is changed.
+ *
+ * @see <a href="https://issues.redhat.com/browse/JBPM-9099">JBPM-9099</a>
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class KieServerQueryDefinitionLoaderStrictModeTest {
+
+    private final Map<String, QueryDefinition> receivedEvents = new HashMap<>();
+
+    private static final int TOTAL_QUERY_DEFINITIONS_EXPECTED = 12;
+
+    @Mock
+    private Event<QueryDefinitionLoaded> event;
+
+    @InjectMocks
+    private KieServerQueryDefinitionLoader kieServerQueryDefinitionLoader;
+
+    @Before
+    public void setup() {
+        openMocks(this);
+        doAnswer(invocation -> {
+            QueryDefinitionLoaded queryDefinitionLoaded = invocation.getArgument(0);
+            receivedEvents.put(queryDefinitionLoaded.getDefinition().getName(), queryDefinitionLoaded.getDefinition());
+            return null;
+        }).when(event).fire(any(QueryDefinitionLoaded.class));
+        this.kieServerQueryDefinitionLoader.init(new Properties(){{
+            put(KieServerQueryDefinitionLoader.JBPM_WB_QUERY_MODE, "STRICT");
+        }});
+    }
+
+    @Test
+    public void testJbpmProcessInstances() {
+        QueryDefinition expectedQuery = QueryDefinition.builder()
+                .name("jbpmProcessInstances")
+                .expression("SELECT LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE ) AS LASTMODIFICATIONDATE, COUNT( ERRINFO.ID ) ERRORCOUNT FROM ProcessInstanceLog LOG LEFT JOIN ExecutionErrorInfo ERRINFO ON ERRINFO.PROCESS_INST_ID=LOG.PROCESSINSTANCEID AND ERRINFO.ERROR_ACK=0 LEFT JOIN ProcessInstanceInfo INFO ON INFO.INSTANCEID=LOG.PROCESSINSTANCEID GROUP BY LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE )")
+                .target("FILTERED_PROCESS")
+                .build();
+        testQueryDefinitionLoaded(expectedQuery);
+    }
+
+    @Test
+    public void testProcessesMonitoring() {
+        QueryDefinition expectedQuery = QueryDefinition.builder()
+                .name("processesMonitoring")
+                .expression("select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, " +
+                                    "log.duration, log.user_identity, log.processVersion, log.processName, " +
+                                    "log.externalId from ProcessInstanceLog log")
+                .target("FILTERED_PROCESS")
+                .build();
+        testQueryDefinitionLoaded(expectedQuery);
+    }
+
+    @Test
+    public void testTasksMonitoring() {
+        QueryDefinition expectedQuery = QueryDefinition.builder()
+                .name("tasksMonitoring")
+                .expression("select p.processName, p.externalId, t.taskId, t.taskName, t.status, t.createdDate, " +
+                                    "t.startDate, t.endDate, t.processInstanceId, t.userId, t.duration " +
+                                    "from ProcessInstanceLog p inner join BAMTaskSummary t on " +
+                                    "(t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk " +
+                                    "from BAMTaskSummary group by taskId) d on t.pk = d.pk")
+                .target("FILTERED_PROCESS")
+                .build();
+        testQueryDefinitionLoaded(expectedQuery);
+    }
+
+    private void testQueryDefinitionLoaded(QueryDefinition expectedQueryDefinition) {
+        assertTrue("No named-queries were found", receivedEvents.size() > 0);
+        assertNotNull("No query definition found for " + expectedQueryDefinition.getName(), receivedEvents.get(expectedQueryDefinition.getName()));
+        assertEquals(expectedQueryDefinition.getExpression(), receivedEvents.get(expectedQueryDefinition.getName()).getExpression());
+        assertEquals(expectedQueryDefinition.getTarget(), receivedEvents.get(expectedQueryDefinition.getName()).getTarget());
+    }
+}

--- a/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoaderTest.java
+++ b/jbpm-wb-kie-server/jbpm-wb-kie-server-backend/src/test/java/org/jbpm/workbench/ks/integration/KieServerQueryDefinitionLoaderTest.java
@@ -75,6 +75,7 @@ public class KieServerQueryDefinitionLoaderTest {
         QueryDefinition expectedQuery = QueryDefinition.builder()
                 .name("jbpmProcessInstances")
                 .expression("SELECT LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE ) AS LASTMODIFICATIONDATE, COUNT( ERRINFO.ID ) ERRORCOUNT FROM ProcessInstanceLog LOG LEFT JOIN ExecutionErrorInfo ERRINFO ON ERRINFO.PROCESS_INST_ID=LOG.PROCESSINSTANCEID AND ERRINFO.ERROR_ACK=0 LEFT JOIN ProcessInstanceInfo INFO ON INFO.INSTANCEID=LOG.PROCESSINSTANCEID GROUP BY LOG.PROCESSINSTANCEID, LOG.PROCESSID, LOG.START_DATE, LOG.END_DATE, LOG.STATUS, LOG.PARENTPROCESSINSTANCEID, LOG.OUTCOME, LOG.DURATION, LOG.USER_IDENTITY, LOG.PROCESSVERSION, LOG.PROCESSNAME, LOG.CORRELATIONKEY, LOG.EXTERNALID, LOG.PROCESSINSTANCEDESCRIPTION, LOG.SLA_DUE_DATE, LOG.SLACOMPLIANCE, COALESCE ( INFO.LASTMODIFICATIONDATE, LOG.END_DATE )")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -87,6 +88,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "vil.variableId, vil.value from VariableInstanceLog vil " +
                                     "left join VariableInstanceLog vil2 on vil.processInstanceId = vil2.processInstanceId " +
                                     "and vil.variableId = vil2.variableId and vil.id < vil2.id where vil2.id is null")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -98,6 +100,7 @@ public class KieServerQueryDefinitionLoaderTest {
                 .expression("select log.processInstanceId, log.processId, log.start_date, log.end_date, log.status, " +
                                     "log.duration, log.user_identity, log.processVersion, log.processName, " +
                                     "log.externalId from ProcessInstanceLog log")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -111,6 +114,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "from ProcessInstanceLog p inner join BAMTaskSummary t on " +
                                     "(t.processInstanceId = p.processInstanceId) inner join (select min(pk) as pk " +
                                     "from BAMTaskSummary group by taskId) d on t.pk = d.pk")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -123,6 +127,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "ri.retries, ri.executions, pil.processName, pil.processInstanceId, " +
                                     "pil.processInstanceDescription, ri.deploymentId from RequestInfo ri left join " +
                                     "ProcessInstanceLog pil on pil.processInstanceId=ri.processInstanceId")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -135,6 +140,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "eri.ACTIVITY_NAME, eri.DEPLOYMENT_ID, eri.ERROR_DATE, eri.ERROR_ID, " +
                                     "eri.ERROR_MSG, eri.JOB_ID, eri.PROCESS_ID, eri.PROCESS_INST_ID, eri.ERROR_TYPE " +
                                     "from ExecutionErrorInfo eri")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -150,6 +156,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "nil.sla_due_date, nil.slaCompliance from AuditTaskImpl t left join " +
                                     "ProcessInstanceLog pil on pil.processInstanceId=t.processInstanceId left join " +
                                     "NodeInstanceLog nil on nil.workItemId=t.workItemId")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -167,6 +174,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "OrganizationalEntity oe on po.entity_id=oe.id left join ProcessInstanceLog pil on " +
                                     "pil.processInstanceId=t.processInstanceId left join PeopleAssignments_ExclOwners eo " +
                                     "on t.taskId=eo.task_id left join NodeInstanceLog nil on nil.workItemId=t.workItemId")
+                .target("FILTERED_PO_TASK")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -185,6 +193,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "left join ProcessInstanceLog pil on pil.processInstanceId = t.processInstanceId " +
                                     "left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe " +
                                     "on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId")
+                .target("FILTERED_BA_TASK")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -206,6 +215,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "left join PeopleAssignments_BAs ba on t.taskId = ba.task_id left join OrganizationalEntity oe " +
                                     "on ba.entity_id = oe.id left join NodeInstanceLog nil on nil.workItemId=t.workItemId " +
                                     "left join Task task on task.id = t.taskId left join I18NText i18n ON i18n.Task_Subjects_Id = t.taskId")
+                .target("FILTERED_BA_TASK")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -215,6 +225,7 @@ public class KieServerQueryDefinitionLoaderTest {
         QueryDefinition expectedQuery = QueryDefinition.builder()
                 .name("jbpmHumanTasksWithVariables")
                 .expression("select tvi.taskId, tvi.name, tvi.value from TaskVariableImpl tvi")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -227,6 +238,7 @@ public class KieServerQueryDefinitionLoaderTest {
                                     "log.processInstanceId, log.log_date, log.connection, log.type, log.workItemId, " +
                                     "log.referenceId, log.nodeContainerId, log.sla_due_date, log.slaCompliance " +
                                     "from NodeInstanceLog log ")
+                .target("CUSTOM")
                 .build();
         testQueryDefinitionLoaded(expectedQuery);
     }
@@ -264,5 +276,6 @@ public class KieServerQueryDefinitionLoaderTest {
         assertTrue("No named-queries were found", receivedEvents.size() > 0);
         assertNotNull("No query definition found for " + expectedQueryDefinition.getName(), receivedEvents.get(expectedQueryDefinition.getName()));
         assertEquals(expectedQueryDefinition.getExpression(), receivedEvents.get(expectedQueryDefinition.getName()).getExpression());
+        assertEquals(expectedQueryDefinition.getTarget(), receivedEvents.get(expectedQueryDefinition.getName()).getTarget());
     }
 }


### PR DESCRIPTION
Introducing a new environment variable `jbpm.wb.querymode` with possible values DEFAULT or STRICT.

If used Strict mode, the queries will be filtered.

By default it'll continue behave as before, without filtering the queries.